### PR TITLE
add set -e to all.bash

### DIFF
--- a/all.bash
+++ b/all.bash
@@ -1,3 +1,5 @@
+set -e
+
 cd cmd
 go install -v ./... # build all Go+ tools
 cd ..


### PR DESCRIPTION
To make all.bash script exit immediately when any command fails.