### PR TITLE
add issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -1,0 +1,19 @@
+name: Bug Report
+description: Report a bug in goplus/gop
+labels: bug
+body:
+  - type: textarea
+    id: problem
+    attributes:
+      label: What happened?
+      description: |
+        Please provide as much info as possible. Not doing so may result in your bug not being addressed in a timely manner.
+    validations:
+      required: true        
+
+  - type: textarea
+    id: expected
+    attributes:
+      label: What did you expect to happen?
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,4 @@
+contact_links:
+  - name: Visit the Go+ website
+    url: https://goplus.org
+    about: Much help can be found there

--- a/.github/ISSUE_TEMPLATE/enhancement.yml
+++ b/.github/ISSUE_TEMPLATE/enhancement.yml
@@ -1,0 +1,17 @@
+name: Enhancement proposal
+description: Propose an enhancement for this project
+labels: enhancement
+body:
+  - type: textarea
+    id: feature
+    attributes:
+      label: What would you like to be added?
+    validations:
+      required: true
+
+  - type: textarea
+    id: rationale
+    attributes:
+      label: Why is this needed?
+    validations:
+      required: true


### PR DESCRIPTION
These templates would provide the following effect when creating issues:
![image](https://user-images.githubusercontent.com/10810759/137326051-1bf76ea7-d334-47e4-9565-9662d9e3ed56.png)

Bug report:
![image](https://user-images.githubusercontent.com/10810759/137326149-90028e82-b012-4540-8408-9e6e6f306717.png)

Enhancement proposal:
![image](https://user-images.githubusercontent.com/10810759/137326235-bf479ebe-77c4-4029-bef7-5c0b0bfd04fe.png)
