### PR TITLE
check parse return error in gop

### DIFF
--- a/cmd/internal/build/build.go
+++ b/cmd/internal/build/build.go
@@ -49,7 +49,7 @@ func init() {
 func runCmd(_ *base.Command, args []string) {
 	err := flag.Parse(base.SkipSwitches(args, flag))
 	if err != nil {
-		log.Fatalln("input arg parse failed:", err)
+		log.Fatalln("parse input arguments failed:", err)
 	}
 	ssargs := flag.Args()
 	dir, recursive := base.GetBuildDir(ssargs)

--- a/cmd/internal/clean/clean.go
+++ b/cmd/internal/clean/clean.go
@@ -101,7 +101,7 @@ func init() {
 func runCmd(_ *base.Command, args []string) {
 	err := flag.Parse(args)
 	if err != nil {
-		log.Fatalln("input arg parse failed:", err)
+		log.Fatalln("parse input arguments failed:", err)
 	}
 	var dir string
 	if flag.NArg() == 0 {

--- a/cmd/internal/gengo/go.go
+++ b/cmd/internal/gengo/go.go
@@ -86,7 +86,7 @@ func init() {
 func runCmd(cmd *base.Command, args []string) {
 	err := flag.Parse(args)
 	if err != nil {
-		log.Fatalln("input arg parse failed:", err)
+		log.Fatalln("parse input arguments failed:", err)
 	}
 	if flag.NArg() < 1 {
 		cmd.Usage(os.Stderr)

--- a/cmd/internal/gopfmt/fmt.go
+++ b/cmd/internal/gopfmt/fmt.go
@@ -117,7 +117,7 @@ func walk(path string, d fs.DirEntry, err error) error {
 func runCmd(cmd *base.Command, args []string) {
 	err := flag.Parse(args)
 	if err != nil {
-		log.Fatalln("input arg parse failed:", err)
+		log.Fatalln("parse input arguments failed:", err)
 	}
 	narg := flag.NArg()
 	if narg < 1 {

--- a/cmd/internal/install/install.go
+++ b/cmd/internal/install/install.go
@@ -45,7 +45,7 @@ func init() {
 func runCmd(_ *base.Command, args []string) {
 	err := flag.Parse(base.SkipSwitches(args, flag))
 	if err != nil {
-		log.Fatalln("input arg parse failed:", err)
+		log.Fatalln("parse input arguments failed:", err)
 	}
 	ssargs := flag.Args()
 	dir, recursive := base.GetBuildDir(ssargs)

--- a/cmd/internal/run/run.go
+++ b/cmd/internal/run/run.go
@@ -96,7 +96,7 @@ func findGoModDir(dir string) (string, bool) {
 func runCmd(cmd *base.Command, args []string) {
 	err := flag.Parse(args)
 	if err != nil {
-		log.Fatalln("input arg parse failed:", err)
+		log.Fatalln("parse input arguments failed:", err)
 	}
 	if flag.NArg() < 1 {
 		cmd.Usage(os.Stderr)

--- a/cmd/internal/test/test.go
+++ b/cmd/internal/test/test.go
@@ -47,7 +47,7 @@ func init() {
 func runCmd(_ *base.Command, args []string) {
 	err := flag.Parse(base.SkipSwitches(args, flag))
 	if err != nil {
-		log.Fatalln("input arg parse failed:", err)
+		log.Fatalln("parse input arguments failed:", err)
 	}
 	ssargs := flag.Args()
 	if len(ssargs) == 0 {


### PR DESCRIPTION
handle flag.Parse error in gop tools 

when args is not ok

before: 
```
gop run -h hello

[FATAL] /Users/arthur/cvt_dev/golang/gop/cmd/internal/run/run.go:125: input arg check failed: stat /Users/arthur/cvt_dev/golang/gop/hello: no such file or directory
```

after:
```
gop run -h hello

[FATAL] /Users/arthur/cvt_dev/golang/gop/cmd/internal/run/run.go:99: input arg parse failed: flag: help requested
```
