### PR TITLE
fix(parser): parse lambda exprs with invalid identifiers as `ast.BadExpr`

### DIFF
--- a/parser/parser.go
+++ b/parser/parser.go
@@ -2608,14 +2608,22 @@ func (p *parser) parseLambdaExpr(allowTuple, allowCmd, allowRangeExpr bool) (x a
 			case *tupleExpr:
 				items := make([]*ast.Ident, len(v.items))
 				for i, item := range v.items {
-					items[i] = p.toIdent(item)
+					ident := p.toIdent(item)
+					if ident == nil {
+						return &ast.BadExpr{From: item.Pos(), To: p.safePos(item.End())}, false
+					}
+					items[i] = ident
 				}
 				lhs, lhsHasParen = items, true
 			case *ast.ParenExpr:
 				e, lhsHasParen = v.X, true
 				goto retry
 			default:
-				lhs = []*ast.Ident{p.toIdent(v)}
+				ident := p.toIdent(v)
+				if ident == nil {
+					return &ast.BadExpr{From: v.Pos(), To: p.safePos(v.End())}, false
+				}
+				lhs = []*ast.Ident{ident}
 			}
 		}
 		if debugParseOutput {

--- a/parser/parser_test.go
+++ b/parser/parser_test.go
@@ -164,6 +164,10 @@ test "hello", (x, "y") => {
 	println "lambda",x,y
 }
 `, `/foo/bar.gop:3:19: expected 'IDENT', found "y"`, ``)
+	testErrCode(t, `onTouchStart "someone" => {
+	say "touched by someone"
+}
+`, `/foo/bar.gop:1:14: expected 'IDENT', found "someone"`, ``)
 }
 
 func TestErrTooManyParseExpr(t *testing.T) {


### PR DESCRIPTION
Fixes goplus/builder#1398
Updates goplus/builder#1402
Closes goplus/tools#330