### PR TITLE
fix(typesutil): fix type checker returned an unexpected error

### DIFF
--- a/cl/stmt.go
+++ b/cl/stmt.go
@@ -399,7 +399,7 @@ func compileRangeStmt(ctx *blockCtx, v *ast.RangeStmt) {
 		return
 	}
 	cb := ctx.cb
-	defer cb.End()
+	defer cb.End(v)
 	defer func() {
 		r := recover()
 		if r != nil {
@@ -470,7 +470,7 @@ func compileForPhraseStmt(ctx *blockCtx, v *ast.ForPhraseStmt) {
 		return
 	}
 	cb := ctx.cb
-	defer cb.End()
+	defer cb.End(v)
 	defer func() {
 		r := recover()
 		if r != nil {
@@ -623,7 +623,7 @@ func toForStmt(forPos token.Pos, value ast.Expr, body *ast.BlockStmt, re *ast.Ra
 // end
 func compileForStmt(ctx *blockCtx, v *ast.ForStmt) {
 	cb := ctx.cb
-	defer cb.End()
+	defer cb.End(v)
 	defer func() {
 		r := recover()
 		if r != nil {
@@ -664,7 +664,7 @@ func compileForStmt(ctx *blockCtx, v *ast.ForStmt) {
 // end
 func compileIfStmt(ctx *blockCtx, v *ast.IfStmt) {
 	cb := ctx.cb
-	defer cb.End()
+	defer cb.End(v)
 	defer func() {
 		r := recover()
 		if r != nil {
@@ -711,7 +711,7 @@ func compileIfStmt(ctx *blockCtx, v *ast.IfStmt) {
 // end
 func compileTypeSwitchStmt(ctx *blockCtx, v *ast.TypeSwitchStmt) {
 	var cb = ctx.cb
-	defer cb.End()
+	defer cb.End(v)
 	defer func() {
 		r := recover()
 		if r != nil {
@@ -811,7 +811,7 @@ func compileTypeSwitchStmt(ctx *blockCtx, v *ast.TypeSwitchStmt) {
 // end
 func compileSwitchStmt(ctx *blockCtx, v *ast.SwitchStmt) {
 	cb := ctx.cb
-	defer cb.End()
+	defer cb.End(v)
 	defer func() {
 		r := recover()
 		if r != nil {
@@ -918,7 +918,7 @@ func hasFallthrough(body []ast.Stmt) ([]ast.Stmt, bool) {
 // end
 func compileSelectStmt(ctx *blockCtx, v *ast.SelectStmt) {
 	cb := ctx.cb
-	defer cb.End()
+	defer cb.End(v)
 	defer func() {
 		r := recover()
 		if r != nil {

--- a/cl/stmt.go
+++ b/cl/stmt.go
@@ -399,6 +399,14 @@ func compileRangeStmt(ctx *blockCtx, v *ast.RangeStmt) {
 		return
 	}
 	cb := ctx.cb
+	defer cb.End()
+	defer func() {
+		r := recover()
+		if r != nil {
+			ctx.handleRecover(r, v)
+			cb.ResetStmt()
+		}
+	}()
 	comments, once := cb.BackupComments()
 	defineNames := make([]*ast.Ident, 0, 2)
 	if v.Tok == token.DEFINE {
@@ -454,7 +462,6 @@ func compileRangeStmt(ctx *blockCtx, v *ast.RangeStmt) {
 	cb.End(v.Body)
 	cb.SetComments(comments, once)
 	setBodyHandler(ctx)
-	cb.End(v)
 }
 
 func compileForPhraseStmt(ctx *blockCtx, v *ast.ForPhraseStmt) {
@@ -463,6 +470,14 @@ func compileForPhraseStmt(ctx *blockCtx, v *ast.ForPhraseStmt) {
 		return
 	}
 	cb := ctx.cb
+	defer cb.End()
+	defer func() {
+		r := recover()
+		if r != nil {
+			ctx.handleRecover(r, v)
+			cb.ResetStmt()
+		}
+	}()
 	comments, once := cb.BackupComments()
 	names := make([]string, 1, 2)
 	defineNames := make([]*ast.Ident, 0, 2)
@@ -505,7 +520,6 @@ func compileForPhraseStmt(ctx *blockCtx, v *ast.ForPhraseStmt) {
 		cb.SetComments(comments, once)
 	}
 	setBodyHandler(ctx)
-	cb.End()
 }
 
 func toForStmt(forPos token.Pos, value ast.Expr, body *ast.BlockStmt, re *ast.RangeExpr, tok token.Token, fp *ast.ForPhrase) *ast.ForStmt {
@@ -609,6 +623,14 @@ func toForStmt(forPos token.Pos, value ast.Expr, body *ast.BlockStmt, re *ast.Ra
 // end
 func compileForStmt(ctx *blockCtx, v *ast.ForStmt) {
 	cb := ctx.cb
+	defer cb.End()
+	defer func() {
+		r := recover()
+		if r != nil {
+			ctx.handleRecover(r, v)
+			cb.ResetStmt()
+		}
+	}()
 	comments, once := cb.BackupComments()
 	cb.For(v)
 	if rec := ctx.recorder(); rec != nil {
@@ -633,7 +655,6 @@ func compileForStmt(ctx *blockCtx, v *ast.ForStmt) {
 	}
 	cb.SetComments(comments, once)
 	setBodyHandler(ctx)
-	cb.End(v)
 }
 
 // if init; cond then
@@ -643,6 +664,14 @@ func compileForStmt(ctx *blockCtx, v *ast.ForStmt) {
 // end
 func compileIfStmt(ctx *blockCtx, v *ast.IfStmt) {
 	cb := ctx.cb
+	defer cb.End()
+	defer func() {
+		r := recover()
+		if r != nil {
+			ctx.handleRecover(r, v)
+			cb.ResetStmt()
+		}
+	}()
 	comments, once := cb.BackupComments()
 	cb.If(v)
 	if v.Init != nil {
@@ -666,7 +695,6 @@ func compileIfStmt(ctx *blockCtx, v *ast.IfStmt) {
 	if rec := ctx.recorder(); rec != nil {
 		rec.Scope(v.Body, cb.Scope())
 	}
-	cb.End(v)
 }
 
 // typeSwitch(name) init; expr typeAssertThen()
@@ -683,6 +711,14 @@ func compileIfStmt(ctx *blockCtx, v *ast.IfStmt) {
 // end
 func compileTypeSwitchStmt(ctx *blockCtx, v *ast.TypeSwitchStmt) {
 	var cb = ctx.cb
+	defer cb.End()
+	defer func() {
+		r := recover()
+		if r != nil {
+			ctx.handleRecover(r, v)
+			cb.ResetStmt()
+		}
+	}()
 	comments, once := cb.BackupComments()
 	var name string
 	var ta *ast.TypeAssertExpr
@@ -759,7 +795,6 @@ func compileTypeSwitchStmt(ctx *blockCtx, v *ast.TypeSwitchStmt) {
 		cb.End(c)
 	}
 	cb.SetComments(comments, once)
-	cb.End(v)
 }
 
 // switch init; tag then
@@ -776,6 +811,14 @@ func compileTypeSwitchStmt(ctx *blockCtx, v *ast.TypeSwitchStmt) {
 // end
 func compileSwitchStmt(ctx *blockCtx, v *ast.SwitchStmt) {
 	cb := ctx.cb
+	defer cb.End()
+	defer func() {
+		r := recover()
+		if r != nil {
+			ctx.handleRecover(r, v)
+			cb.ResetStmt()
+		}
+	}()
 	comments, once := cb.BackupComments()
 	cb.Switch(v)
 	if v.Init != nil {
@@ -844,7 +887,6 @@ func compileSwitchStmt(ctx *blockCtx, v *ast.SwitchStmt) {
 		cb.End(c)
 	}
 	cb.SetComments(comments, once)
-	cb.End(v)
 }
 
 func hasFallthrough(body []ast.Stmt) ([]ast.Stmt, bool) {
@@ -876,6 +918,14 @@ func hasFallthrough(body []ast.Stmt) ([]ast.Stmt, bool) {
 // end
 func compileSelectStmt(ctx *blockCtx, v *ast.SelectStmt) {
 	cb := ctx.cb
+	defer cb.End()
+	defer func() {
+		r := recover()
+		if r != nil {
+			ctx.handleRecover(r, v)
+			cb.ResetStmt()
+		}
+	}()
 	comments, once := cb.BackupComments()
 	cb.Select(v)
 	for _, stmt := range v.Body.List {
@@ -896,7 +946,6 @@ func compileSelectStmt(ctx *blockCtx, v *ast.SelectStmt) {
 		cb.End(c)
 	}
 	cb.SetComments(comments, once)
-	cb.End(v)
 }
 
 func compileBranchStmt(ctx *blockCtx, v *ast.BranchStmt) {

--- a/x/typesutil/check_test.go
+++ b/x/typesutil/check_test.go
@@ -300,23 +300,54 @@ func TestCheckError2(t *testing.T) {
 	var checkerErrs errors.List
 	fset := token.NewFileSet()
 	checkFilesWithErrorHandler(fset, "main.xgo", `
-type GG struct {
+type Foo struct {
 	B bool
 }
 
-doublejump := 2
-gotdoublejump := false
-jumping := false
-gg := &GG{B: true}
-if doublejump == 2 && !gotdoublejump {
-	println("Double jump activated!")
-} else if doublejump == 1 && gotdoublejump {
-	if !jumping {
-		jumping = true
+bar := 2
+gotbar := false
+boolBar := false
+gg := &Foo{B: true}
+if bar == 2 && !gotbar {
+	println("wow!")
+} else if bar == 1 && gotbar {
+	if !boolBar {
+		boolBar = true
 		for i := 0; i < 20; i++ {
 			if gg.P {
-				println("Double jump!")
+				println("wow 2!")
 			}
+		}
+	}
+}
+`, "", "", "", "", func(err error) {
+		checkerErrs.Add(err)
+	})
+
+	if len(checkerErrs) > 1 {
+		t.Fatal("too many errors")
+	}
+}
+
+func TestCheckError3(t *testing.T) {
+	var checkerErrs errors.List
+	fset := token.NewFileSet()
+	checkFilesWithErrorHandler(fset, "main.xgo", `
+type Foo struct {
+	B []string
+}
+
+bar := 2
+gotbar := false
+boolBar := false
+gg := &Foo{B: []string{"hello", "world"}}
+if bar == 2 && !gotbar {
+	println("Double jump activated!")
+} else if bar == 1 && gotbar {
+	if !boolBar {
+		boolBar = true
+		for item := range gg.P {
+			println("i am item", item)
 		}
 	}
 }


### PR DESCRIPTION
fix: https://github.com/nighca/builder-experience/issues/32

1. When processing the inner expr, panic occurs.
2. The corresponding stmt does not call end.
3. This lack of an end causes the code context to not be restored to the old code context.
4. Ultimately, when the outer stmt processes the remaining expr, the code context is incorrectly verified, causing another panic.