### PR TITLE
feat(cl): add check function to embed method for conditional field addition

### DIFF
--- a/cl/classfile.go
+++ b/cl/classfile.go
@@ -87,13 +87,15 @@ type gmxProject struct {
 	hasMain_   bool
 }
 
-func (p *gmxProject) embed(flds []*types.Var, pkg *gogen.Package) []*types.Var {
+func (p *gmxProject) embed(chk func(name string) bool, flds []*types.Var, pkg *gogen.Package) []*types.Var {
 	for _, sp := range p.sprites {
 		if sp.feats&spriteEmbedded != 0 {
 			for _, spt := range sp.types {
-				spto := pkg.Ref(spt)                // work class
-				pt := types.NewPointer(spto.Type()) // pointer to work class
-				flds = append(flds, types.NewField(token.NoPos, pkg.Types, spto.Name(), pt, false))
+				spto := pkg.Ref(spt) // work class
+				if chk != nil && !chk(spto.Name()) {
+					pt := types.NewPointer(spto.Type()) // pointer to work class
+					flds = append(flds, types.NewField(token.NoPos, pkg.Types, spto.Name(), pt, false))
+				}
 			}
 		}
 	}
@@ -477,7 +479,7 @@ func gmxProjMain(pkg *gogen.Package, parent *pkgCtx, proj *gmxProject) {
 				baseType = types.NewPointer(baseType)
 			}
 
-			flds := proj.embed([]*types.Var{
+			flds := proj.embed(nil, []*types.Var{
 				types.NewField(token.NoPos, pkg.Types, base.Name(), baseType, true),
 			}, pkg)
 

--- a/cl/cltest/cltest.go
+++ b/cl/cltest/cltest.go
@@ -90,6 +90,11 @@ func LookupClass(ext string) (c *modfile.Project, ok bool) {
 			Ext: ".t4gmx", Class: "*MyGame",
 			Works:    []*modfile.Class{{Ext: ".t4spx", Class: "Sprite"}},
 			PkgPaths: []string{"github.com/goplus/xgo/cl/internal/spx4", "math"}}, true
+	case ".t5gmx", ".t5spx":
+		return &modfile.Project{
+			Ext: ".t5gmx", Class: "*MyGame",
+			Works:    []*modfile.Class{{Ext: ".t5spx", Class: "Sprite", Embedded: true}},
+			PkgPaths: []string{"github.com/goplus/xgo/cl/internal/spx4", "math"}}, true
 	case "_spx.gox":
 		return &modfile.Project{
 			Ext: "_spx.gox", Class: "Game",

--- a/cl/compile.go
+++ b/cl/compile.go
@@ -830,7 +830,9 @@ func preloadGopFile(p *gogen.Package, ctx *blockCtx, file string, f *ast.File, c
 							}
 						}
 					} else { // embed work classes for project class
-						flds = proj.embed(flds, p)
+						flds = proj.embed(func(name string) bool {
+							return chk.chkRedecl(ctx, name, pos, end)
+						}, flds, p)
 					}
 				}
 				rec := ctx.recorder()

--- a/cl/compile_spx_test.go
+++ b/cl/compile_spx_test.go
@@ -107,6 +107,17 @@ Greem.t4spx:1:1: cannot use  (type *Greem) as type github.com/goplus/xgo/cl/inte
 	}, map[string]string{
 		"/foo/Game.t4gmx": `println backdropName!`,
 	})
+
+	gopSpxErrorTestEx(t, `Game.t5gmx:4:2: Kai redeclared
+	Game.t5gmx:1:1 other declaration of Kai
+Kai.t5spx:1:1: cannot use  (type *Kai) as type github.com/goplus/xgo/cl/internal/spx4.Sprite in argument to `, `
+
+var (
+	Kai Kai
+)
+`, `
+println "hi"
+`, "Game.t5gmx", "Kai.t5spx")
 }
 
 func TestSpxBasic(t *testing.T) {


### PR DESCRIPTION
fixed: https://github.com/goplus/builder/issues/2047

After we use embed, we no longer need to use autobinding. If we continue to write a variable that duplicates the embed 
field, we expect an error to be reported in advance instead of panicking when Newstruct is reached.