### PR TITLE
chore(build): add `-trimpath` and `mod_timestamp` for reproducible builds

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -10,27 +10,33 @@ builds:
   - id: xgo
     main: ./cmd/xgo
     binary: bin/xgo
+    flags:
+      - -trimpath
     ldflags:
       - -X github.com/goplus/xgo/env.buildVersion=v{{.Version}}
-      - -X github.com/goplus/xgo/env.buildDate={{.Date}}
+      - -X github.com/goplus/xgo/env.buildDate={{.CommitDate}}
     env:
       - CGO_ENABLED=0
     goos:
       - linux
       - windows
       - darwin
+    mod_timestamp: "{{ .CommitTimestamp }}"
   - id: gop
     main: ./cmd/xgo
     binary: bin/gop
+    flags:
+      - -trimpath
     ldflags:
       - -X github.com/goplus/xgo/env.buildVersion=v{{.Version}}
-      - -X github.com/goplus/xgo/env.buildDate={{.Date}}
+      - -X github.com/goplus/xgo/env.buildDate={{.CommitDate}}
     env:
       - CGO_ENABLED=0
     goos:
       - linux
       - windows
       - darwin
+    mod_timestamp: "{{ .CommitTimestamp }}"
 
 archives:
   - format: tar.gz

--- a/cmd/make.go
+++ b/cmd/make.go
@@ -371,7 +371,7 @@ func buildGoplusTools(useGoProxy bool) {
 	println("Building XGo tools...\n")
 	os.Chdir(commandsDir)
 
-	buildOutput, err := execCommand("go", "build", "-o", gopBinPath, "-v", "-ldflags", buildFlags, "./...")
+	buildOutput, err := execCommand("go", "build", "-o", gopBinPath, "-v", "-trimpath", "-ldflags", buildFlags, "./...")
 	if err != nil {
 		log.Fatalln(err)
 	}


### PR DESCRIPTION
See https://goreleaser.com/blog/reproducible-builds/