### PR TITLE
chore(release): migrate to `dockers_v2` from GoReleaser 2.12

### DIFF
--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -81,6 +81,7 @@ jobs:
         args: release --clean -p 4
       env:
         GITHUB_TOKEN: ${{ github.token }}
+        DOCKER_IMAGE_REPO: ghcr.io/${{ github.repository }}
         WINGET_PKGS_PRIVATE_KEY: ${{ secrets.WINGET_PKGS_PRIVATE_KEY }}
 
     - name: Upload deb/rpm to Fury.io

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -1,5 +1,8 @@
 version: 2
 
+env:
+  - DOCKER_IMAGE_REPO={{ envOrDefault "DOCKER_IMAGE_REPO" "xgo" }}
+
 dist: .dist
 
 before:
@@ -83,62 +86,24 @@ changelog:
       - "^docs:"
       - "^test:"
 
-dockers:
-  - goarch: "386"
-    image_templates:
-      - ghcr.io/{{ envOrDefault "GITHUB_REPOSITORY" "goplus/xgo" }}:{{ .Version }}-386
-    use: buildx
-    build_flag_templates:
-      - --platform=linux/386
-      - --build-arg=USE_GORELEASER_ARTIFACTS=1
-      - --build-arg=GORELEASER_ARTIFACTS_TARBALL=.dist/{{.ProjectName}}{{.Version}}.linux-386.tar.gz
+dockers_v2:
+  - id: xgo
+    dockerfile: Dockerfile
+    images:
+      - "{{ .Env.DOCKER_IMAGE_REPO }}"
+    tags:
+      - "{{ .Version }}"
+      - "{{ .Major }}.{{ .Minor }}"
+      - "{{ .Major }}"
+      - latest
+    platforms:
+      - linux/386
+      - linux/amd64
+      - linux/arm64
+    build_args:
+      USE_GORELEASER_ARTIFACTS: "1"
     extra_files:
       - ./
-  - goarch: amd64
-    image_templates:
-      - ghcr.io/{{ envOrDefault "GITHUB_REPOSITORY" "goplus/xgo" }}:{{ .Version }}-amd64
-    use: buildx
-    build_flag_templates:
-      - --platform=linux/amd64
-      - --build-arg=USE_GORELEASER_ARTIFACTS=1
-      - --build-arg=GORELEASER_ARTIFACTS_TARBALL=.dist/{{.ProjectName}}{{.Version}}.linux-amd64.tar.gz
-    extra_files:
-      - ./
-  - goarch: arm64
-    image_templates:
-      - ghcr.io/{{ envOrDefault "GITHUB_REPOSITORY" "goplus/xgo" }}:{{ .Version }}-arm64
-    use: buildx
-    build_flag_templates:
-      - --platform=linux/arm64
-      - --build-arg=USE_GORELEASER_ARTIFACTS=1
-      - --build-arg=GORELEASER_ARTIFACTS_TARBALL=.dist/{{.ProjectName}}{{.Version}}.linux-arm64.tar.gz
-    extra_files:
-      - ./
-
-docker_manifests:
-  - name_template: ghcr.io/{{ envOrDefault "GITHUB_REPOSITORY" "goplus/xgo" }}:{{ .Version }}
-    image_templates:
-      - ghcr.io/{{ envOrDefault "GITHUB_REPOSITORY" "goplus/xgo" }}:{{ .Version }}-386
-      - ghcr.io/{{ envOrDefault "GITHUB_REPOSITORY" "goplus/xgo" }}:{{ .Version }}-amd64
-      - ghcr.io/{{ envOrDefault "GITHUB_REPOSITORY" "goplus/xgo" }}:{{ .Version }}-arm64
-  - name_template: ghcr.io/{{ envOrDefault "GITHUB_REPOSITORY" "goplus/xgo" }}:{{ .Major }}.{{ .Minor }}
-    image_templates:
-      - ghcr.io/{{ envOrDefault "GITHUB_REPOSITORY" "goplus/xgo" }}:{{ .Version }}-386
-      - ghcr.io/{{ envOrDefault "GITHUB_REPOSITORY" "goplus/xgo" }}:{{ .Version }}-amd64
-      - ghcr.io/{{ envOrDefault "GITHUB_REPOSITORY" "goplus/xgo" }}:{{ .Version }}-arm64
-    skip_push: auto
-  - name_template: ghcr.io/{{ envOrDefault "GITHUB_REPOSITORY" "goplus/xgo" }}:{{ .Major }}
-    image_templates:
-      - ghcr.io/{{ envOrDefault "GITHUB_REPOSITORY" "goplus/xgo" }}:{{ .Version }}-386
-      - ghcr.io/{{ envOrDefault "GITHUB_REPOSITORY" "goplus/xgo" }}:{{ .Version }}-amd64
-      - ghcr.io/{{ envOrDefault "GITHUB_REPOSITORY" "goplus/xgo" }}:{{ .Version }}-arm64
-    skip_push: auto
-  - name_template: ghcr.io/{{ envOrDefault "GITHUB_REPOSITORY" "goplus/xgo" }}:latest
-    image_templates:
-      - ghcr.io/{{ envOrDefault "GITHUB_REPOSITORY" "goplus/xgo" }}:{{ .Version }}-386
-      - ghcr.io/{{ envOrDefault "GITHUB_REPOSITORY" "goplus/xgo" }}:{{ .Version }}-amd64
-      - ghcr.io/{{ envOrDefault "GITHUB_REPOSITORY" "goplus/xgo" }}:{{ .Version }}-arm64
-    skip_push: auto
 
 winget:
   - name: goplus

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,8 +2,8 @@ ARG BASE_IMAGE=golang:1.24-bookworm
 
 FROM $BASE_IMAGE AS build
 
+ARG TARGETPLATFORM
 ARG USE_GORELEASER_ARTIFACTS=0
-ARG GORELEASER_ARTIFACTS_TARBALL
 
 WORKDIR /usr/local/src/xgo
 COPY . .
@@ -15,7 +15,7 @@ XGOROOT=/usr/local/xgo
 mkdir -p "$XGOROOT"
 
 if [ "$USE_GORELEASER_ARTIFACTS" -eq 1 ]; then
-	tar -xzf "$GORELEASER_ARTIFACTS_TARBALL" -C "$XGOROOT"
+	cp -rp "$TARGETPLATFORM"/* "$XGOROOT"/
 else
 	git ls-tree --full-tree --name-only -r HEAD | grep -vE "^\." | xargs -I {} cp --parents {} "$XGOROOT"/
 	./all.bash


### PR DESCRIPTION
Migrate from the legacy `dockers` configuration to the new `dockers_v2` format introduced in GoReleaser 2.12[^1].

The migration eliminates the need for the `docker_manifests` section entirely and streamlines the Dockerfile by using `TARGETPLATFORM` for multi-arch builds instead of architecture-specific tarball handling.

[^1]: https://goreleaser.com/blog/goreleaser-v2.12/