### PR TITLE
chore(deps): bump github.com/goplus/gogen from 1.19.6 to 1.19.9-0.20260114155758-01b7b91c31d1

### DIFF
--- a/cl/compile_test.go
+++ b/cl/compile_test.go
@@ -2170,6 +2170,7 @@ type foo struct {
 }
 
 func (p *foo) Gop_Enum() fooIter {
+	return fooIter{}
 }
 
 for k, v <- new(foo) {
@@ -2188,6 +2189,7 @@ func (p fooIter) Next() (key string, val int, ok bool) {
 	return
 }
 func (p *foo) Gop_Enum() fooIter {
+	return fooIter{}
 }
 func main() {
 	for _xgo_it := new(foo).Gop_Enum(); ; {
@@ -3610,10 +3612,12 @@ func TestGoFuncInstr(t *testing.T) {
 //go:noinline
 //go:uintptrescapes
 func test(s string, p, q uintptr, rest ...uintptr) int {
+	return 0
 }`, `package main
 //go:noinline
 //go:uintptrescapes
 func test(s string, p uintptr, q uintptr, rest ...uintptr) int {
+	return 0
 }
 `)
 }

--- a/cl/stmt.go
+++ b/cl/stmt.go
@@ -195,6 +195,11 @@ retry:
 }
 
 func compileReturnStmt(ctx *blockCtx, expr *ast.ReturnStmt) {
+	// Use defer to ensure Return is always called, even if argument compilation
+	// fails. This guarantees the return statement is recorded in AST for control
+	// flow analysis, preventing spurious "missing return" errors.
+	defer ctx.cb.Return(len(expr.Results), expr)
+
 	var n = -1
 	var results *types.Tuple
 	for i, ret := range expr.Results {
@@ -235,7 +240,6 @@ func compileReturnStmt(ctx *blockCtx, expr *ast.ReturnStmt) {
 			}
 		}
 	}
-	ctx.cb.Return(len(expr.Results), expr)
 }
 
 func compileIncDecStmt(ctx *blockCtx, expr *ast.IncDecStmt) {

--- a/demo/xgo-calc/calc.xgo
+++ b/demo/xgo-calc/calc.xgo
@@ -19,8 +19,9 @@ func calc(e ast.Expr) float64 {
 		case token.MUL:
 			return calc(e.X) * calc(e.Y)
 		case token.QUO:
-			return calc(e.X) + calc(e.Y)
+			return calc(e.X) / calc(e.Y)
 		}
+		panic("unknown binary operator")
 	case *ast.CallExpr:
 		switch e.Fun.(*ast.Ident).Name {
 		case "sin":
@@ -30,6 +31,7 @@ func calc(e ast.Expr) float64 {
 		case "pow":
 			return math.Pow(calc(e.Args[0]), calc(e.Args[1]))
 		}
+		panic("unknown function")
 	case *ast.ParenExpr:
 		return calc(e.X)
 	case *ast.UnaryExpr:
@@ -37,6 +39,7 @@ func calc(e ast.Expr) float64 {
 		case token.SUB:
 			return -calc(e.X)
 		}
+		panic("unknown unary operator")
 	}
 	panic("unknown expression")
 }

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.18
 require (
 	github.com/fsnotify/fsnotify v1.9.0
 	github.com/goplus/cobra v1.9.12 //gop:class
-	github.com/goplus/gogen v1.19.6
+	github.com/goplus/gogen v1.19.9-0.20260114155758-01b7b91c31d1
 	github.com/goplus/lib v0.3.1
 	github.com/goplus/mod v0.18.0
 	github.com/qiniu/x v1.15.3

--- a/go.sum
+++ b/go.sum
@@ -2,8 +2,8 @@ github.com/fsnotify/fsnotify v1.9.0 h1:2Ml+OJNzbYCTzsxtv8vKSFD9PbJjmhYF14k/jKC7S
 github.com/fsnotify/fsnotify v1.9.0/go.mod h1:8jBTzvmWwFyi3Pb8djgCCO5IBqzKJ/Jwo8TRcHyHii0=
 github.com/goplus/cobra v1.9.12 h1:0F9EdEbeGyITGz+mqoHoJ5KpUw97p1CkxV74IexHw5s=
 github.com/goplus/cobra v1.9.12/go.mod h1:p4LhfNJDKEpiGjGiNn0crUXL5dUPA5DX2ztYpEJR34E=
-github.com/goplus/gogen v1.19.6 h1:NbWqC3WtBJQvwORPra6za0KRi01w4kAeAYMscZCt4j4=
-github.com/goplus/gogen v1.19.6/go.mod h1:owX2e1EyU5WD+Nm6oH2m/GXjLdlBYcwkLO4wN8HHXZI=
+github.com/goplus/gogen v1.19.9-0.20260114155758-01b7b91c31d1 h1:EdifGUikxCno9Ok8hgXCbk1mNgCiAbwB9YCJ5L84PlM=
+github.com/goplus/gogen v1.19.9-0.20260114155758-01b7b91c31d1/go.mod h1:owX2e1EyU5WD+Nm6oH2m/GXjLdlBYcwkLO4wN8HHXZI=
 github.com/goplus/lib v0.3.1 h1:Xws4DBVvgOMu58awqB972wtvTacDbk3nqcbHjdx9KSg=
 github.com/goplus/lib v0.3.1/go.mod h1:SgJv3oPqLLHCu0gcL46ejOP3x7/2ry2Jtxu7ta32kp0=
 github.com/goplus/mod v0.18.0 h1:ae25ShC5IFsGd+cqC9b3amgHp5iKvvZt/l21YbxMLo0=


### PR DESCRIPTION
This also adapts `compileReturnStmt` to use defer for calling `Return`, ensuring return statements are recorded in AST even when argument compilation fails, preventing spurious "missing return" errors.

Updates goplus/gogen#557