### PR TITLE
fix(classfile): sanitize reserved class type names

### DIFF
--- a/cl/builtin_test.go
+++ b/cl/builtin_test.go
@@ -316,6 +316,8 @@ func TestFileClassType(t *testing.T) {
 		{true, true, false, "Abc.gox", "Abc", false, true},
 		{true, true, false, "abc_demo.gox", "abc", false, true},
 		{true, true, false, "Abc_demo.gox", "Abc", false, true},
+		{true, true, false, "chan.gox", "_chan", false, true},
+		{true, true, false, "chan_demo.gox", "_chan", false, true},
 
 		{true, true, false, "main.gox", "_main", false, true},
 		{true, true, false, "main_demo.gox", "_main", false, true},
@@ -332,7 +334,10 @@ func TestFileClassType(t *testing.T) {
 
 		{true, false, false, "abc_yap.gox", "abc", false, true},
 		{true, false, false, "Abc_yap.gox", "Abc", false, true},
+		{true, false, false, "chan_yap.gox", "_chan", false, true},
 		{true, false, true, "main_yap.gox", "App", false, true},
+		{true, false, true, "chan_app.gox", "_chan", false, true},
+		{true, false, false, "chan_cmd.gox", "Cmd_chan", false, true},
 
 		{true, false, true, "abc_yap.gox", "abc", false, true},
 		{true, false, true, "Abc_yap.gox", "Abc", false, true},
@@ -353,6 +358,13 @@ func TestFileClassType(t *testing.T) {
 			return &modfile.Project{
 				Ext: "_yap.gox", Class: "App",
 				PkgPaths: []string{"github.com/goplus/yap"}}, true
+		case "_app.gox", "_cmd.gox":
+			return &modfile.Project{
+				Ext: "_app.gox", Class: "App",
+				Works: []*modfile.Class{
+					{Ext: "_cmd.gox", Class: "Command", Prefix: "Cmd_"},
+				},
+				PkgPaths: []string{"github.com/goplus/cobra/xcmd"}}, true
 		case "_ytest.gox":
 			return &modfile.Project{
 				Ext: "_ytest.gox", Class: "App",

--- a/cl/classfile.go
+++ b/cl/classfile.go
@@ -225,17 +225,24 @@ func GetFileClassType(file *ast.File, filename string, lookupClass func(ext stri
 		classType, _, ext = ClassNameAndExt(filename)
 		if file.IsNormalGox {
 			isTest = strings.HasSuffix(ext, "_test.gox")
-			if !isTest && classType == "main" {
-				classType = "_main"
+			if !isTest {
+				classType = sanitizeClassTypeName(classType)
 			}
 		} else {
 			isTest = strings.HasSuffix(ext, "test.gox")
-		}
-		if file.IsProj && classType == "main" {
 			if gt, ok := lookupClass(ext); ok {
-				classType = gt.Class
+				if file.IsProj {
+					if classType == "main" {
+						classType = gt.Class
+					} else {
+						classType = sanitizeClassTypeName(classType)
+					}
+				} else {
+					classType = workClassTypeNameByExt(gt, ext, classType)
+				}
 			}
-		} else if isTest {
+		}
+		if !file.IsProj && isTest {
 			classType = casePrefix + testNameSuffix(classType)
 		}
 	} else if strings.HasSuffix(filename, "_test.xgo") || strings.HasSuffix(filename, "_test.gop") {
@@ -307,6 +314,9 @@ func loadClass(ctx *pkgCtx, pkg *gogen.Package, file string, f *ast.File, conf *
 		if p.gameClass_ != "" {
 			panic("multiple project files found: " + tname + ", " + p.gameClass_)
 		}
+		if tname != "main" {
+			tname = sanitizeClassTypeName(tname)
+		}
 		p.gameClass_ = tname
 		p.hasMain_ = f.HasShadowEntry()
 		if !p.isTest {
@@ -334,18 +344,34 @@ type none = struct{}
 var specialNames = map[string]none{
 	"init": {}, "main": {}, "go": {}, "goto": {}, "type": {}, "var": {}, "import": {},
 	"package": {}, "interface": {}, "struct": {}, "const": {}, "func": {}, "map": {},
-	"for": {}, "if": {}, "else": {}, "switch": {}, "case": {}, "select": {}, "defer": {},
+	"chan": {}, "for": {}, "if": {}, "else": {}, "switch": {}, "case": {}, "select": {}, "defer": {},
 	"range": {}, "return": {}, "break": {}, "continue": {}, "fallthrough": {}, "default": {},
+}
+
+func sanitizeClassTypeName(name string) string {
+	if _, ok := specialNames[name]; ok {
+		return "_" + name
+	}
+	return name
+}
+
+func workClassTypeNameByExt(gt *Project, ext, name string) string {
+	for _, work := range gt.Works {
+		if work.Ext == ext {
+			if work.Prefix != "" {
+				return work.Prefix + name
+			}
+			break
+		}
+	}
+	return sanitizeClassTypeName(name)
 }
 
 func spName(sp *spxObj, name string) string {
 	if sp.prefix != "" {
 		return sp.prefix + name
 	}
-	if _, ok := specialNames[name]; ok {
-		name = "_" + name
-	}
-	return name
+	return sanitizeClassTypeName(name)
 }
 
 func getSpxObj(p *gmxProject, ext string) *spxObj {

--- a/cl/compile.go
+++ b/cl/compile.go
@@ -814,6 +814,7 @@ func preloadXGoFile(p *gogen.Package, ctx *blockCtx, file string, f *ast.File, c
 	if f.IsClass {
 		if f.IsNormalGox {
 			classType, _, _ = ClassNameAndExt(file)
+			classType = sanitizeClassTypeName(classType)
 			if f.ShadowEntry != nil {
 				parent.goxMainClass = classType
 				parent.goxMain++

--- a/cl/compile_spx_test.go
+++ b/cl/compile_spx_test.go
@@ -1061,6 +1061,25 @@ type foo struct {
 `, "foo.gox")
 }
 
+func TestGoxReservedTypeName(t *testing.T) {
+	gopClTestFile(t, `
+println "hi"
+`, `package main
+
+import "fmt"
+
+type _chan struct {
+}
+
+func (this *_chan) Main() {
+	fmt.Println("hi")
+}
+func main() {
+	new(_chan).Main()
+}
+`, "chan.gox")
+}
+
 func TestGoxOverload(t *testing.T) {
 	gopClTestFile(t, `
 func addString(a, b string) string {

--- a/doc/classfile-spec.md
+++ b/doc/classfile-spec.md
@@ -13,7 +13,6 @@ There are two kinds of classfiles:
 The following terms are used throughout this document:
 - Class extension: the normalized classfile suffix used for framework lookup, e.g., `_app.gox` and `.gsh`
 - Class file stem: the filename without the class extension
-- Class file name: the class file stem before any type-name normalization
 - Class type: the generated named type for a classfile
 - Field declaration block: the unique top-level `var` declaration that is interpreted as class fields rather than
   package variables
@@ -90,6 +89,7 @@ Ignoring comments, a classfile has the following top-level structure:
 ```ebnf
 Classfile = [ PackageClause ] { ImportDecl } { ClassDecl } [ TopLevelStmtList ] .
 ClassDecl = ConstDecl | TypeDecl | VarDecl | FuncDecl .
+TopLevelStmtList = StatementList .
 ```
 
 The optional `TopLevelStmtList` must be the final top-level construct in the file. After the first top-level statement
@@ -132,6 +132,10 @@ Tag            = string_lit .
 The following special rule applies only inside the field declaration block:
 - A spec consisting of exactly one identifier, with no explicit type and no initializer, declares an embedded field
   whose type is that identifier
+- This is the only case in which `IdentifierList` may appear without either a `Type` or an `=` initializer
+
+For any other `FieldSpec`, ordinary `var`-declaration validity rules apply. In particular, at least a `Type` or an `=`
+initializer must be present.
 
 Examples:
 
@@ -165,15 +169,16 @@ The class file stem is normalized as follows:
 
 Examples:
 - `Rect.gox` produces the initial type name `Rect`
-- `get_p_#id_app.gox` has class file name `get_p_#id` and normalized type name `get_p_id`
+- `get_p_#id_app.gox` has class file stem `get_p_#id` and normalized type name `get_p_id`
 
 Framework metadata may further transform the type name:
-- A non-empty work-class `-prefix=` is prepended to the normalized work-file stem
-- If no prefix is supplied and the work-file stem equals one of the reserved names `init`, `main`, `go`, `goto`, `type`,
-  `var`, `import`, `package`, `interface`, `struct`, `const`, `func`, `map`, `for`, `if`, `else`, `switch`, `case`,
-  `select`, `defer`, `range`, `return`, `break`, `continue`, `fallthrough`, or `default`, an underscore is prepended
 - A project file whose class file stem is `main`, or a framework that has no explicit project file, uses the project
   base-class name as its default class type name. A leading `*` on the base-class name is removed
+- A non-empty work-class `-prefix=` is prepended to the normalized work-file stem
+- If neither of the previous rules applies and the class type name would otherwise equal one of the reserved names
+  `init`, `main`, `go`, `goto`, `type`, `var`, `import`, `package`, `interface`, `struct`, `const`, `func`, `map`,
+  `chan`, `for`, `if`, `else`, `switch`, `case`, `select`, `defer`, `range`, `return`, `break`, `continue`,
+  `fallthrough`, or `default`, an underscore is prepended
 
 The generated class type must be unique within the package after all such normalization.
 
@@ -224,7 +229,7 @@ A top-level function declaration that already has an explicit receiver is not re
 
 ### Static method declaration
 
-The classfile parser also accepts the following classfile-only declaration form:
+The classfile parser also accepts the following classfile-only `FuncDecl` form:
 
 ```ebnf
 StaticMethodDecl = "func" "." identifier Signature [ FunctionBody ] .
@@ -463,7 +468,7 @@ If the work prototype contains a method named `Classfname`, the compiler generat
 func (this *T) Classfname() string
 ```
 
-The method returns the class file name, which is the class file stem before type-name normalization.
+The method returns the class file stem.
 
 Examples:
 - `hello_tool.gox` yields `hello`
@@ -471,8 +476,9 @@ Examples:
 
 ### `Classclone`
 
-If the work prototype contains a method named `Classclone`, the compiler generates a shallow-clone method with the
-required signature.
+If the work prototype contains a method named `Classclone`, the compiler generates a shallow-clone method named
+`Classclone` with no parameters other than the receiver. Its result list is adopted from the prototype's `Classclone`
+declaration.
 
 The generated implementation copies `*this` by value into a temporary variable and returns the address of that temporary
 value.


### PR DESCRIPTION
Apply keyword-safe class type naming consistently across classfile compilation.

Add `chan` to the reserved-name set and use the same sanitization rule for normal `.gox` files, explicit project classfiles, and work classfiles without `-prefix=` so generated Go type names stay valid.

Keep `GetFileClassType` aligned with the actual compilation result and add tests for reserved-name handling.

Sync `doc/classfile-spec.md` with the reserved-name change and keep the related wording self-consistent where the updated rule is described.

Updates #2675