### PR TITLE
fix(tool): use xgo version as cache hash for bundled packages

### DIFF
--- a/tool/imp.go
+++ b/tool/imp.go
@@ -122,10 +122,7 @@ func (p *Importer) PkgHash(pkgPath string, self bool) string {
 		}
 	}
 	if isPkgInMod(pkgPath, xgoMod) || isPkgInMod(pkgPath, xMod) {
-		if v := p.xgo.Version; v != "" {
-			return v
-		}
-		return cache.HashInvalid
+		return p.xgo.Version
 	}
 	log.Println("PkgHash: unexpected package -", pkgPath)
 	return cache.HashInvalid


### PR DESCRIPTION
https://github.com/goplus/xgo/issues/2688