### PR TITLE
docs: add classfile resource specification

### DIFF
--- a/doc/classfile-resource-spec.md
+++ b/doc/classfile-resource-spec.md
@@ -1,0 +1,500 @@
+# The XGo classfile resource specification
+
+This document defines the syntax and semantics of resources in XGo classfile frameworks.
+
+A resource is a framework-defined named entity that is visible to static analysis.
+
+In particular, this document defines:
+- how a framework declares resource kinds and type-level resource bindings
+- how a framework discovers concrete resource instances through DQL over pack documents
+- how a framework declares API-position scope bindings for scoped resource references
+- how work classfiles may imply top-level resource identities
+- how source-level resource references participate in standardized static semantics
+
+## Terms
+
+The following terms are used throughout this document:
+- Resource kind: a framework-defined resource category such as `sprite`, `sound`, or `sprite.costume`
+- Top-level kind: a resource kind with no direct parent kind
+- Scoped kind: a resource kind whose instances exist within the scope of another resource kind
+- Framework package: the package named by the first package path of one project group
+- String-based type: an exported defined type or exported alias whose type has underlying type `string`
+- Canonical resource reference type: a string-based type bound to one resource kind
+- Handle-bearing type: an exported defined interface type or exported defined struct type whose values may carry one
+  top-level resource identity of one resource kind
+- Local resource name: the name of one resource instance within its direct parent scope, or at top level if its
+  resource kind is top-level
+- Scope chain: the ordered chain of ancestor resource identities from the outermost ancestor to the direct parent
+- Scope-unknown reference: a scoped resource reference whose complete scope chain is not statically available
+- Framework registration identity: the identity of one project group in the active classfile registry
+- Resource identity: the stable logical identity of a resource instance, independent from storage path, manifest path,
+  URI syntax, and runtime object identity
+- Resource instance: one concrete resource available to static analysis in one classfile project under one framework
+  registration
+- Resource-discovery comment: a framework source directive comment that declares one concrete resource discovery query
+  for one canonical resource reference type
+- Resource-name-discovery comment: a framework source directive comment that declares one local resource name discovery
+  query for one canonical resource reference type
+- Pack document: the pack document defined by the XGo classfile specification
+- Discovery origin node: one node matched by a resource-discovery comment query and associated with one discovered
+  resource instance
+- Callable site: one framework function declaration, one framework method declaration, or one interface method spec
+  declared by one top-level handle-bearing interface type declaration
+- API position: the receiver or one numbered parameter position of one callable site
+- Resource-api-scope-binding comment: a framework source directive comment that declares one direct API-position scope
+  binding for one scoped canonical resource reference type parameter position
+- Resource-bearing work file kind: a work file kind whose work classfiles each imply one top-level resource instance
+- Resource set: the set of concrete resource instances available to one implementation for one classfile project and one
+  framework registration
+- Resource reference: a source-level reference to a resource
+
+The logical identity of a resource instance is the tuple:
+- framework registration identity
+- resource kind
+- optional scope chain
+- local resource name
+
+In this specification, the resource kind in a resource identity is the instance's own kind. It does not encode any
+concrete ancestor identities, even when the kind spelling uses dotted segments such as `sprite.costume.frame`.
+
+## Notation
+
+The syntax in this document is specified using EBNF. It uses the same EBNF conventions as the XGo classfile
+specification and the Go specification.
+
+```ebnf
+ResourceComment = "//xgo:class:resource" ResourceKind .
+ResourceDiscoveryComment = "//xgo:class:resource-discovery" StandardDQLQuery .
+ResourceNameDiscoveryComment = "//xgo:class:resource-name-discovery" StandardDQLQuery .
+ResourceAPIScopeBindingComment = "//xgo:class:resource-api-scope-binding" ScopeBindingTarget ScopeBindingSource .
+
+ResourceKind = ResourceSegment { "." ResourceSegment } .
+ResourceSegment = lower_letter { lower_letter | decimal_digit | "_" } .
+ScopeBindingTarget = ParameterPosition .
+ScopeBindingSource = "receiver" | ParameterPosition .
+ParameterPosition = "param." decimal_digit { decimal_digit } .
+lower_letter = "a" ... "z" .
+```
+
+The lexical production `decimal_digit` is as in the Go specification. The directive comment form is as in Go directive
+comment conventions.
+
+`StandardDQLQuery` is the remaining text of one resource-discovery or resource-name-discovery comment line and must be
+one standard DQL query.
+
+`ResourceComment` attaches to one immediately following top-level type spec that declares exactly one exported type name
+and no type parameters.
+
+`ParameterPosition` uses zero-based decimal indexing in ordinary parameter source order and must not use leading zeros
+other than `0` itself.
+
+In one dotted `ResourceKind`, each `.` separates one nested resource-kind segment from its direct parent prefix. A
+single-segment kind is top-level. A multi-segment kind is scoped. The direct parent kind of one multi-segment kind is
+the prefix that remains after removing its final `.` segment.
+
+## Conformance
+
+An implementation conforms to this specification if it implements the syntax and semantics defined by this specification
+and satisfies every rule stated using the terms "must" and "must not".
+
+Rules stated using "may" describe permitted behavior. Rules stated using "should" describe recommended behavior.
+
+Capabilities such as hover, completion, diagnostics, rename, and references are optional tool capabilities. If an
+implementation provides one of those capabilities for standardized resource semantics, the capability must satisfy all
+applicable "must" and "must not" rules in this specification.
+
+## Framework source metadata
+
+Framework source metadata declares which resource kinds exist, how source code refers to them, which canonical resource
+reference types carry discovery queries and optional local-name discovery queries, and how framework callable sites may
+provide explicit direct scope to scoped resource positions.
+
+### Resource comments
+
+A resource comment belongs to the immediately following top-level type spec that declares exactly one exported type name
+and no type parameters in the framework package of the containing project group.
+
+A resource comment on any other declaration, on one grouped type declaration as a whole rather than on one contained
+type spec, or in any other package, has no standardized meaning in this specification.
+
+A declaration must not bear more than one resource comment with standardized meaning.
+
+A resource kind is declared when a resource comment with standardized meaning names it.
+
+If the declaration bearing a resource comment is a string-based type:
+- the comment declares the canonical resource reference type of the named resource kind
+- the declaration is the canonical resource reference type declaration of that kind
+
+If the declaration bearing a resource comment is an exported defined interface type or exported defined struct type:
+- the comment declares a handle-bearing type of the named resource kind
+- the named resource kind must be top-level
+
+If the declaration bearing a resource comment is neither a string-based type nor an exported defined interface type nor
+an exported defined struct type, the comment has no standardized meaning in this specification.
+
+Within one project group:
+- the direct parent kind of each scoped kind must be declared in the same project group
+- a resource kind must not have more than one canonical resource reference type
+- a declaration that bears a resource comment with standardized meaning must belong to the framework package of the
+  containing project group
+
+A top-level resource kind may have zero, one, or more handle-bearing types.
+
+A handle-bearing type declaration does not by itself imply any resource instance and does not by itself define any
+source-level resource-binding rule.
+
+Additional user-facing spellings may be expressed through ordinary Go aliases that reduce to the canonical resource
+reference type of a kind and do not bear their own resource comments.
+
+### Resource-discovery comments
+
+A resource-discovery comment belongs to the immediately following declaration only if all of the following hold:
+- the declaration is the canonical resource reference type declaration of one resource kind
+- the declaration is in the framework package of the containing project group
+
+A resource-discovery comment on any other declaration, in any other package, or on the same declaration as another
+resource-discovery comment, has no standardized meaning in this specification.
+
+Each canonical resource reference type declaration may bear at most one resource-discovery comment with standardized
+meaning.
+
+A resource-discovery comment declares one DQL query for discovering concrete resource instances of that resource kind.
+
+### Resource-name-discovery comments
+
+A resource-name-discovery comment belongs to the immediately following declaration only if all of the following hold:
+- the declaration is the canonical resource reference type declaration of one resource kind
+- the declaration is in the framework package of the containing project group
+- the same declaration bears one resource-discovery comment with standardized meaning
+
+A resource-name-discovery comment on any other declaration, in any other package, or on the same declaration as another
+resource-name-discovery comment, has no standardized meaning in this specification.
+
+Each canonical resource reference type declaration may bear at most one resource-name-discovery comment with
+standardized meaning.
+
+A resource-name-discovery comment declares one DQL query for discovering local resource names of that resource kind
+relative to discovery origin nodes.
+
+### Resource-api-scope-binding comments
+
+A resource-api-scope-binding comment belongs to the immediately following callable site only if all of the following
+hold:
+- the callable site is one top-level function declaration, one top-level method declaration, or one method spec declared
+  by one top-level handle-bearing interface type declaration
+- the callable site is in the framework package of the containing project group
+
+A resource-api-scope-binding comment on any other callable site, in any other package, or on the same callable site as
+another resource-api-scope-binding comment with the same target parameter position, has no standardized meaning in this
+specification.
+
+Each callable site may bear zero or more resource-api-scope-binding comments with standardized meaning, but at most one
+such comment may target one parameter position.
+
+A set of resource-api-scope-binding comments with standardized meaning on one callable site must induce an acyclic
+directed relation over API positions.
+
+The meaning of one resource-api-scope-binding comment is independent of its source order relative to other such comments
+on the same callable site.
+
+A resource-api-scope-binding comment declares one direct scope source for its target parameter position.
+
+## Concrete resource introduction
+
+Concrete resource introduction in this specification occurs either through resource-discovery comments and optional
+resource-name-discovery comments over pack documents or through work classfile implication.
+
+### Discovery-based introduction
+
+Resource-discovery comments and optional resource-name-discovery comments introduce project-derived resource instances
+over pack documents.
+
+#### Discovery execution
+
+For a top-level resource kind, the resource-discovery comment query is evaluated on the root node of the pack document,
+if any, derived from the active project group identified by the current framework registration identity.
+
+For a scoped resource kind whose direct parent kind is `<parentKind>`, the resource-discovery comment query is evaluated
+relative to each discovery origin node of each discovered direct parent resource instance of kind `<parentKind>`.
+
+Relative evaluation means that the discovery origin node is used as the DQL query root for that evaluation.
+
+If a direct parent resource identity is available only from work-classfile implication and not from any discovery origin
+node, that implied identity alone does not create a relative discovery root.
+
+An implementation must preserve at least one discovery origin node for each discovered resource instance.
+
+If one discovered resource identity is obtained from more than one discovery origin node, relative child discovery is
+evaluated for each such origin node. Child identities obtained from those evaluations are merged by resource identity.
+
+If a canonical resource reference type declaration bears a resource-name-discovery comment, its query is evaluated
+relative to each discovery origin node produced by the resource-discovery comment on that declaration.
+
+Relative evaluation of a resource-name-discovery comment does not change the discovery origin node associated with the
+discovered resource instance and does not create any relative discovery root for child discovery.
+
+#### Discovery result interpretation
+
+A successful resource-discovery comment query match contributes one discovered resource instance candidate.
+
+For the rules below:
+- a string scalar value is one pack-document string scalar value
+- a node key name is the key by which one matched node appears as one member of its containing pack-document object, if
+  any
+- a string member named `name` is one object member named `name` whose value is a string scalar value
+
+The candidate's local resource name is determined as follows:
+- if a resource-name-discovery comment is present:
+  - if its relative evaluation for that candidate does not produce exactly one matched node, the candidate is invalid
+    for discovery and does not contribute a resource instance
+  - if that matched node denotes a string scalar value, that string value is the local resource name
+  - otherwise, if the matched node has a non-empty node key name, that key name is the local resource name
+  - otherwise, if the matched node has a string member named `name`, the value of that member is the local resource name
+  - otherwise, the candidate is invalid for discovery and does not contribute a resource instance
+- otherwise:
+  - if the discovery origin node has a non-empty node key name, that key name is the local resource name
+  - otherwise, if the discovery origin node has a string member named `name`, the value of that member is the local
+    resource name
+  - otherwise, the candidate is invalid for discovery and does not contribute a resource instance
+
+For a top-level kind, the discovered identity is `(resource kind, local resource name)`.
+
+For a scoped kind, the discovered identity is `(resource kind, scope chain, local resource name)`, where the direct
+parent identity is inherited from the current relative discovery execution context.
+
+### Work classfile implication
+
+If a handle-bearing type declaration bearing a resource comment is the registered work base class declaration of one or
+more work file kinds, each such work file kind is resource-bearing.
+
+A resource-bearing work file kind implies one top-level resource instance for each work classfile of that kind in the
+analyzed classfile project.
+
+The implied local resource name is the class file stem of the work classfile, before any class type naming normalization
+or `-prefix=` application.
+
+The implied resource identity is independent from generated Go type naming, including `-prefix=` adjustments.
+
+This rule standardizes one classfile-native top-level resource identity. Framework-specific runtime lookup keys,
+reflection binding keys, and generated Go identifiers remain framework-defined.
+
+This rule affects only the static resource model. Compilation and runtime behavior remain unchanged.
+
+Only work classfiles may imply resources through this rule.
+
+A work file kind must not imply more than one top-level resource kind through this rule.
+
+If two or more work classfiles imply the same resource identity in one analyzed classfile project:
+- the identities collide
+- an implementation may report a duplicate-resource diagnostic
+- the colliding inputs must not be treated as distinct resource instances
+
+Implied resources from project classfiles and scoped classfile-implied resources are outside the scope of this
+specification.
+
+### Identity merging
+
+If more than one source contributes the same resource identity, including resource-discovery comments and work-classfile
+implication:
+- they refer to the same logical resource instance
+- metadata may merge
+- the contributing sources must not change the resource kind, scope chain, or local resource name of that identity
+
+An implementation may preserve one origin, many origins, or provenance in a different internal form, subject to the
+relative-discovery requirements above.
+
+### Example
+
+```go
+// SpriteName identifies a sprite by name.
+//
+//xgo:class:resource sprite
+//xgo:class:resource-discovery sprites.*
+type SpriteName = string
+
+// SpriteCostumeName identifies a sprite costume by name.
+//
+//xgo:class:resource sprite.costume
+//xgo:class:resource-discovery costumes.*
+type SpriteCostumeName = string
+
+// WidgetName identifies a widget by name.
+//
+//xgo:class:resource widget
+//xgo:class:resource-discovery widgets.*
+//xgo:class:resource-name-discovery id
+type WidgetName = string
+
+// SpriteImpl is a handle-bearing type of the sprite resource kind.
+//
+//xgo:class:resource sprite
+type SpriteImpl struct{}
+```
+
+If one pack document contains `sprites.Hero`, the `sprite` query may discover `sprite(Hero)` and preserve `sprites.Hero`
+as one discovery origin node of that resource. The `sprite.costume` query is then evaluated relative to that origin
+node, so it may discover costumes of `Hero` without embedding `Hero` into the query text.
+
+If one `widget` origin node stores its local resource name in a child member `id` rather than in its node key or a child
+member `name`, the `resource-name-discovery` query `id` is evaluated relative to that origin node and yields the local
+resource name.
+
+If the containing project group declares `class .spx SpriteImpl`, the resource comment on `SpriteImpl` makes `.spx`
+resource-bearing, and each `.spx` work classfile implies one top-level `sprite` resource instance whose local resource
+name is the class file stem.
+
+## Static semantics
+
+### Resource references
+
+A source position participates in standardized resource semantics only if ordinary Go typing determines one canonical
+resource reference type declaration of one resource kind for that position.
+
+For this purpose, a canonical resource reference type declaration is determined for a source expression in one of the
+following ways:
+- the expression's static type is that canonical resource reference type declaration, or can be reduced to it by
+  following Go alias declarations only
+- the surrounding typed position requires that canonical resource reference type, and the expression is assignable to it
+  under ordinary Go typing rules
+
+A distinct defined type does not participate in standardized resource semantics solely because both it and a canonical
+resource reference type have underlying type `string`.
+
+A Go alias declaration denotes the same resource kind as that canonical resource reference type if its denoted type can
+be reduced, recursively through Go alias declarations only, to the same canonical resource reference type declaration.
+
+An expression is canonically resource-typed if one canonical resource reference type declaration is determined for it in
+that way.
+
+For one canonically resource-typed expression:
+- if the expression is a string literal or a statically evaluable string constant, it is a resource reference candidate
+- if the expression cannot be statically evaluated, it remains resource-typed but is not a resolvable resource reference
+- for a top-level kind, the lookup key is `(resource kind, local resource name)`
+- for a scoped kind, the lookup key is `(resource kind, scope chain, local resource name)`
+- if a scoped kind does not have a statically available complete scope chain, the reference is one `scope-unknown`
+  reference
+
+### API-position scope bindings
+
+In this subsection, the callable site is the function declaration, method declaration, or interface method spec to which
+one resource-api-scope-binding comment with standardized meaning belongs.
+
+One resource-api-scope-binding comment has standardized meaning only if all of the following hold:
+- the target parameter position exists on the callable site
+- the target parameter position is not the variadic parameter position of the callable site
+- the target parameter type determines one canonical resource reference type declaration of one scoped kind
+- the source API position exists on the callable site
+- if the source API position is one parameter position, it is not the variadic parameter position of the callable site
+- the source API position determines either:
+  - one canonical resource reference type declaration of the direct parent kind of the target kind, or
+  - one handle-bearing type of that direct parent kind
+
+At one call that resolves to that callable site, the source API position is interpreted as follows:
+- if the source API position is `receiver`, the source expression is the call's receiver expression, whether explicit or
+  implicit
+- if the source API position is one parameter position, the source expression is the corresponding argument expression
+
+One resource-api-scope-binding comment contributes one explicit direct parent identity to its target argument position
+only if the source expression yields one exact resource identity of the target kind's direct parent kind under the
+resource semantics otherwise available at that source position.
+
+For this purpose, a source position may itself use explicit scope contributed by other resource-api-scope-binding
+comments on the same callable site, subject to the acyclicity rule above.
+
+If the target kind is multiply scoped, a resource-api-scope-binding comment contributes at most the direct parent
+identity. Any additional ancestor levels come from that direct parent identity's own scope chain, if available.
+
+If a target position receives one explicit direct parent identity from a resource-api-scope-binding comment, that
+identity is explicit scope for that target position.
+
+Example:
+
+```go
+//xgo:class:resource-api-scope-binding param.0 receiver
+func (p *SpriteImpl) SetCostume__0(costume SpriteCostumeName)
+
+//xgo:class:resource-api-scope-binding param.0 receiver
+//xgo:class:resource-api-scope-binding param.1 param.0
+func (p *SpriteImpl) SetCostumeAndFrame(costume SpriteCostumeName, frame SpriteCostumeFrameName)
+```
+
+If one call to `SetCostume__0` yields one exact `sprite` identity at its receiver position, the bound
+`SpriteCostumeName` argument position may use that identity as explicit scope.
+
+If one call to `SetCostumeAndFrame` yields one exact `sprite` identity at its receiver position, `param.0` may use that
+identity as explicit scope. If `param.0` then yields one exact `sprite.costume` identity, the bound
+`SpriteCostumeFrameName` argument position may use that identity as explicit scope.
+
+### Scoped owner inference
+
+If all of the following hold:
+- the current source position is inside a work classfile
+- the registered work base class declaration of that work file kind bears a resource comment for one top-level kind
+  `<parentKind>`
+- the referenced scoped kind has direct parent kind `<parentKind>`
+- no explicit scope is otherwise statically available
+
+then the statically available direct parent identity is the implied top-level resource of the containing work classfile.
+
+Example:
+- if the declaration of `SpriteImpl` bears `//xgo:class:resource sprite`
+- and `class .spx SpriteImpl` is active
+- and `SpriteCostumeName` bears `//xgo:class:resource sprite.costume`
+- then a scoped `SpriteCostumeName` reference inside `Hero.spx` may use scope `(sprite, Hero)`
+
+If a resource-api-scope-binding comment contributes explicit scope to one target position, that explicit scope takes
+precedence over the narrow rule above for that target position.
+
+Receiver-bound owner inference, project auto-binding owner inference, and other framework-specific context rules remain
+framework-specific.
+
+If the narrow rule above does not apply, the scoped reference remains `scope-unknown`.
+
+The narrow rule above contributes at most one statically available parent identity. It does not by itself infer any
+additional ancestor levels for multiply scoped kinds.
+
+If a framework uses plain `string` parameters or resource-like values that do not reduce to canonical resource reference
+types, those positions are outside the standardized resource semantics of this specification.
+
+### Diagnostics
+
+A conforming implementation:
+- may emit a "resource not found" diagnostic only when its framework-specific discovery semantics are exact for the
+  analyzed project state
+- must not emit a "resource not found" diagnostic for dynamic expressions
+- must not emit a "resource not found" diagnostic for `scope-unknown` references
+- may emit a diagnostic for an empty resource name
+
+## Tool semantics
+
+### Hover
+
+When a source position resolves to a resource reference whose identity is present in the implementation's resource set,
+an implementation that provides hover must return information about the corresponding resource instance.
+
+### Completion
+
+When the target type at an input position resolves to a resource kind, an implementation that provides completion may
+base resource completion candidates on the implementation's resource set.
+
+For scoped kinds:
+- if the scope chain is known, completion must be filtered to that scope chain
+- if the scope chain is unknown, an implementation may suppress completion or provide degraded completion annotated with
+  scope information
+
+### Rename and references
+
+If an implementation supports rename or reference lookup for resources, resource identity must be based on
+`(framework registration identity, resource kind, optional scope chain, local resource name)` rather than raw string
+text.
+
+## Excluded semantics
+
+This specification intentionally does not standardize:
+- framework-specific API-position scope rules beyond explicit resource-api-scope-binding comments
+- API-position kind binding rules for positions that do not already depend on canonical resource reference types
+- implied resources from project classfiles
+- scoped classfile-implied resources beyond the work-classfile implication rule defined by this specification
+- how runtime parameters such as `run(...)` are mapped back into static analysis
+- the concrete encoding of preview URIs or editor-specific payloads
+- one standardized completeness or exactness model for resource discovery

--- a/doc/classfile-resource-spec.md
+++ b/doc/classfile-resource-spec.md
@@ -1,0 +1,506 @@
+# The XGo classfile resource specification
+
+This document defines the syntax and semantics of resources in XGo classfile frameworks.
+
+A resource is a framework-defined named entity that is visible to static analysis.
+
+In particular, this document defines:
+- how a framework declares resource kinds and type-level resource bindings
+- how a framework discovers concrete resource instances through DQL over pack documents
+- how a framework declares API-position scope bindings for scoped resource references
+- how work classfiles may imply top-level resource identities
+- how source-level resource references participate in standardized static semantics
+
+## Terms
+
+The following terms are used throughout this document:
+- Resource kind: a framework-defined resource category such as `sprite`, `sound`, or `sprite.costume`
+- Top-level kind: a resource kind with no direct parent kind
+- Scoped kind: a resource kind whose instances exist within the scope of another resource kind
+- Framework package: the package named by the first package path of one project group
+- Framework registration identity: the identity of one framework registration in the classfile registry
+- String-based type: an exported defined type or exported alias whose type has underlying type `string`
+- Canonical resource reference type: a string-based type bound to one resource kind
+- Handle-bearing type: an exported defined interface type or exported defined struct type whose values may carry one
+  top-level resource identity of one resource kind
+- Local resource name: the name of one resource instance within its direct parent scope, or at top level if its resource
+  kind is top-level
+- Scope chain: the ordered chain of ancestor resource identities from the outermost ancestor to the direct parent
+- Resource identity: the stable logical identity of a resource instance, independent from storage path, manifest path,
+  URI syntax, and runtime object identity
+- Resource instance: one concrete resource available to static analysis in one classfile project under one framework
+  registration
+- Resource-discovery comment: a framework source directive comment that declares one concrete resource discovery query
+  fragment for one canonical resource reference type
+- Resource-name-discovery comment: a framework source directive comment that declares one local resource name discovery
+  query fragment for one canonical resource reference type
+- Pack document: the pack document defined by the XGo classfile specification
+- Discovery origin node: one node matched by a resource-discovery comment query fragment and associated with one
+  discovered resource instance
+- Callable site: one framework function declaration, one framework method declaration, or one interface method spec
+  declared by one top-level handle-bearing interface type declaration
+- API position: the receiver or one numbered parameter position of one callable site
+- Resource-api-scope-binding comment: a framework source directive comment that declares one direct API-position scope
+  binding for one scoped canonical resource reference type parameter position
+- Resource-bearing work file kind: a work file kind whose work classfiles each imply one top-level resource instance
+- Resource set: the set of concrete resource instances available to one implementation for one classfile project and one
+  framework registration
+- Resource reference: a source-level reference to a resource
+- Scope-unknown reference: a scoped resource reference whose complete scope chain is not statically available
+
+The logical identity of a resource instance is the tuple:
+- framework registration identity
+- resource kind
+- optional scope chain
+- local resource name
+
+In this specification, the resource kind in a resource identity is the instance's own kind. It does not encode any
+concrete ancestor identities, even when the kind spelling uses dotted segments such as `sprite.costume.frame`.
+
+## Notation
+
+The syntax in this document is specified using EBNF. It uses the same EBNF conventions as the XGo classfile
+specification and the Go specification.
+
+```ebnf
+ResourceComment = "//xgo:class:resource" ResourceKind .
+ResourceDiscoveryComment = "//xgo:class:resource-discovery" DQLQueryFragment .
+ResourceNameDiscoveryComment = "//xgo:class:resource-name-discovery" DQLQueryFragment .
+ResourceAPIScopeBindingComment = "//xgo:class:resource-api-scope-binding" ScopeBindingTarget ScopeBindingSource .
+
+ResourceKind = ResourceSegment { "." ResourceSegment } .
+ResourceSegment = lower_letter { lower_letter | decimal_digit | "_" } .
+ScopeBindingTarget = ParameterPosition .
+ScopeBindingSource = "receiver" | ParameterPosition .
+ParameterPosition = "param." decimal_digit { decimal_digit } .
+lower_letter = "a" ... "z" .
+```
+
+The lexical production `decimal_digit` is as in the Go specification. The directive comment form is as in Go directive
+comment conventions.
+
+`DQLQueryFragment` is the remaining text of one resource-discovery or resource-name-discovery comment line and must be
+one DQL query fragment. It is evaluated relative to an implicit root supplied by the discovery execution context.
+
+`ResourceComment` attaches to one immediately following top-level type spec that declares exactly one exported type name
+and no type parameters.
+
+`ParameterPosition` uses zero-based decimal indexing in ordinary parameter source order and must not use leading zeros
+other than `0` itself.
+
+In one dotted `ResourceKind`, each `.` separates one nested resource-kind segment from its direct parent prefix. A
+single-segment kind is top-level. A multi-segment kind is scoped. The direct parent kind of one multi-segment kind is
+the prefix that remains after removing its final `.` segment.
+
+## Conformance
+
+An implementation conforms to this specification if it implements the syntax and semantics defined by this specification
+and satisfies every rule stated using the terms "must" and "must not".
+
+Rules stated using "may" describe permitted behavior. Rules stated using "should" describe recommended behavior.
+
+Capabilities such as hover, completion, diagnostics, rename, and references are optional tool capabilities. If an
+implementation provides one of those capabilities for standardized resource semantics, the capability must satisfy all
+applicable "must" and "must not" rules in this specification.
+
+## Framework source metadata
+
+Framework source metadata declares which resource kinds exist, how source code refers to them, which canonical resource
+reference types carry discovery query fragments and optional local-name discovery query fragments, and how framework
+callable sites may provide explicit direct scope to scoped resource positions.
+
+### Resource comments
+
+A resource comment belongs to the immediately following top-level type spec that declares exactly one exported type name
+and no type parameters in the framework package of the containing project group.
+
+A resource comment on any other declaration, on one grouped type declaration as a whole rather than on one contained
+type spec, or in any other package, has no standardized meaning in this specification.
+
+A declaration must not bear more than one resource comment with standardized meaning.
+
+A resource kind is declared when a resource comment with standardized meaning names it.
+
+If the declaration bearing a resource comment is a string-based type:
+- the comment declares the canonical resource reference type of the named resource kind
+- the declaration is the canonical resource reference type declaration of that kind
+
+If the declaration bearing a resource comment is an exported defined interface type or exported defined struct type:
+- the comment declares a handle-bearing type of the named resource kind
+- the named resource kind must be top-level
+
+If the declaration bearing a resource comment is neither a string-based type nor an exported defined interface type nor
+an exported defined struct type, the comment has no standardized meaning in this specification.
+
+Within one project group:
+- the direct parent kind of each scoped kind must be declared in the same project group
+- a resource kind must not have more than one canonical resource reference type
+- a declaration that bears a resource comment with standardized meaning must belong to the framework package of the
+  containing project group
+
+A top-level resource kind may have zero, one, or more handle-bearing types.
+
+A handle-bearing type declaration does not by itself imply any resource instance and does not by itself define any
+source-level resource-binding rule.
+
+Additional user-facing spellings may be expressed through ordinary Go aliases that reduce to the canonical resource
+reference type of a kind and do not bear their own resource comments.
+
+### Resource-discovery comments
+
+A resource-discovery comment belongs to the immediately following declaration only if all of the following hold:
+- the declaration is the canonical resource reference type declaration of one resource kind
+- the declaration is in the framework package of the containing project group
+
+A resource-discovery comment on any other declaration, in any other package, or on the same declaration as another
+resource-discovery comment, has no standardized meaning in this specification.
+
+Each canonical resource reference type declaration may bear at most one resource-discovery comment with standardized
+meaning.
+
+A resource-discovery comment declares one DQL query fragment for discovering concrete resource instances of that
+resource kind.
+
+### Resource-name-discovery comments
+
+A resource-name-discovery comment belongs to the immediately following declaration only if all of the following hold:
+- the declaration is the canonical resource reference type declaration of one resource kind
+- the declaration is in the framework package of the containing project group
+- the same declaration bears one resource-discovery comment with standardized meaning
+
+A resource-name-discovery comment on any other declaration, in any other package, or on the same declaration as another
+resource-name-discovery comment, has no standardized meaning in this specification.
+
+Each canonical resource reference type declaration may bear at most one resource-name-discovery comment with
+standardized meaning.
+
+A resource-name-discovery comment declares one DQL query fragment for discovering local resource names of that resource
+kind relative to discovery origin nodes.
+
+### Resource-api-scope-binding comments
+
+A resource-api-scope-binding comment belongs to the immediately following callable site only if all of the following
+hold:
+- the callable site is one top-level function declaration, one top-level method declaration, or one method spec declared
+  by one top-level handle-bearing interface type declaration
+- the callable site is in the framework package of the containing project group
+
+A resource-api-scope-binding comment on any other callable site, in any other package, or on the same callable site as
+another resource-api-scope-binding comment with the same target parameter position, has no standardized meaning in this
+specification.
+
+Each callable site may bear zero or more resource-api-scope-binding comments with standardized meaning, but at most one
+such comment may target one parameter position.
+
+A set of resource-api-scope-binding comments with standardized meaning on one callable site must induce an acyclic
+directed relation over API positions.
+
+The meaning of one resource-api-scope-binding comment is independent of its source order relative to other such comments
+on the same callable site.
+
+A resource-api-scope-binding comment declares one direct scope source for its target parameter position.
+
+## Concrete resource introduction
+
+Concrete resource introduction in this specification occurs either through resource-discovery comments and optional
+resource-name-discovery comments over pack documents or through work classfile implication.
+
+### Discovery-based introduction
+
+Resource-discovery comments and optional resource-name-discovery comments introduce project-derived resource instances
+over pack documents.
+
+#### Discovery execution
+
+For a top-level resource kind, the resource-discovery comment query fragment is evaluated relative to the root node of
+the pack document, if any, derived from the active project group identified by the current framework registration
+identity.
+
+For a scoped resource kind whose direct parent kind is `<parentKind>`, the resource-discovery comment query fragment is
+evaluated relative to each discovery origin node of each discovered direct parent resource instance of kind
+`<parentKind>`.
+
+Relative evaluation means that the discovery origin node is used as the implicit DQL root for that evaluation.
+
+If a direct parent resource identity is available only from work-classfile implication and not from any discovery origin
+node, that implied identity alone does not create a relative discovery root.
+
+An implementation must preserve at least one discovery origin node for each discovered resource instance.
+
+If one discovered resource identity is obtained from more than one discovery origin node, relative child discovery is
+evaluated for each such origin node. Child identities obtained from those evaluations are merged by resource identity.
+
+If a canonical resource reference type declaration bears a resource-name-discovery comment, its query fragment is
+evaluated relative to each discovery origin node produced by the resource-discovery comment on that declaration.
+
+Relative evaluation of a resource-name-discovery comment does not change the discovery origin node associated with the
+discovered resource instance and does not create any relative discovery root for child discovery.
+
+#### Discovery result interpretation
+
+A successful resource-discovery comment query fragment match contributes one discovered resource instance candidate.
+
+For the rules below:
+- a string scalar value is one pack-document string scalar value
+- a node key name is the key by which one matched node appears as one member of its containing pack-document object, if
+  any
+- a string member named `name` is one object member named `name` whose value is a string scalar value
+
+The candidate's local resource name is determined as follows:
+- if a resource-name-discovery comment is present:
+  - if its relative evaluation for that candidate does not produce exactly one matched node, the candidate is invalid
+    for discovery and does not contribute a resource instance
+  - if that matched node denotes a string scalar value, that string value is the local resource name
+  - otherwise, if the matched node has a non-empty node key name, that key name is the local resource name
+  - otherwise, if the matched node has a string member named `name`, the value of that member is the local resource name
+  - otherwise, the candidate is invalid for discovery and does not contribute a resource instance
+- otherwise:
+  - if the discovery origin node has a non-empty node key name, that key name is the local resource name
+  - otherwise, if the discovery origin node has a string member named `name`, the value of that member is the local
+    resource name
+  - otherwise, the candidate is invalid for discovery and does not contribute a resource instance
+
+For a top-level kind, the discovered identity is `(resource kind, local resource name)`.
+
+For a scoped kind, the discovered identity is `(resource kind, scope chain, local resource name)`, where the direct
+parent identity is inherited from the current relative discovery execution context.
+
+### Work classfile implication
+
+If a handle-bearing type declaration bearing a resource comment is the registered work base class declaration of one or
+more work file kinds, each such work file kind is resource-bearing.
+
+A resource-bearing work file kind implies one top-level resource instance for each work classfile of that kind in the
+analyzed classfile project.
+
+The implied local resource name is the class file stem of the work classfile, before any class type naming normalization
+or `-prefix=` application.
+
+The implied resource identity is independent from generated Go type naming, including `-prefix=` adjustments.
+
+This rule standardizes one classfile-native top-level resource identity. Framework-specific runtime lookup keys,
+reflection binding keys, and generated Go identifiers remain framework-defined.
+
+This rule affects only the static resource model. Compilation and runtime behavior remain unchanged.
+
+Only work classfiles may imply resources through this rule.
+
+A project fragment in a flat project group is not a work classfile and does not imply a resource through this rule.
+
+A work file kind must not imply more than one top-level resource kind through this rule.
+
+If two or more work classfiles imply the same resource identity in one analyzed classfile project:
+- the identities collide
+- an implementation may report a duplicate-resource diagnostic
+- the colliding inputs must not be treated as distinct resource instances
+
+Implied resources from project classfiles and scoped classfile-implied resources are outside the scope of this
+specification.
+
+### Identity merging
+
+If more than one source contributes the same resource identity, including resource-discovery comments and work-classfile
+implication:
+- they refer to the same logical resource instance
+- metadata may merge
+- the contributing sources must not change the resource kind, scope chain, or local resource name of that identity
+
+An implementation may preserve one origin, many origins, or provenance in a different internal form, subject to the
+relative-discovery requirements above.
+
+### Example
+
+```go
+// SpriteName identifies a sprite by name.
+//
+//xgo:class:resource sprite
+//xgo:class:resource-discovery sprites.*
+type SpriteName = string
+
+// SpriteCostumeName identifies a sprite costume by name.
+//
+//xgo:class:resource sprite.costume
+//xgo:class:resource-discovery costumes.*
+type SpriteCostumeName = string
+
+// WidgetName identifies a widget by name.
+//
+//xgo:class:resource widget
+//xgo:class:resource-discovery widgets.*
+//xgo:class:resource-name-discovery id
+type WidgetName = string
+
+// SpriteImpl is a handle-bearing type of the sprite resource kind.
+//
+//xgo:class:resource sprite
+type SpriteImpl struct{}
+```
+
+If one pack document contains `sprites.Hero`, the `sprite` query fragment may discover `sprite(Hero)` and preserve
+`sprites.Hero` as one discovery origin node of that resource. The `sprite.costume` query fragment is then evaluated
+relative to that origin node, so it may discover costumes of `Hero` without embedding `Hero` into the query text.
+
+If one `widget` origin node stores its local resource name in a child member `id` rather than in its node key or a child
+member `name`, the `resource-name-discovery` query fragment `id` is evaluated relative to that origin node and yields
+the local resource name.
+
+If the containing project group declares `class .spx SpriteImpl`, the resource comment on `SpriteImpl` makes `.spx`
+resource-bearing, and each `.spx` work classfile implies one top-level `sprite` resource instance whose local resource
+name is the class file stem.
+
+## Static semantics
+
+### Resource references
+
+A source position participates in standardized resource semantics only if ordinary Go typing determines one canonical
+resource reference type declaration of one resource kind for that position.
+
+For this purpose, a canonical resource reference type declaration is determined for a source expression in one of the
+following ways:
+- the expression's static type is that canonical resource reference type declaration, or can be reduced to it by
+  following Go alias declarations only
+- the surrounding typed position requires that canonical resource reference type, and the expression is assignable to it
+  under ordinary Go typing rules
+
+A distinct defined type does not participate in standardized resource semantics solely because both it and a canonical
+resource reference type have underlying type `string`.
+
+A Go alias declaration denotes the same resource kind as that canonical resource reference type if its denoted type can
+be reduced, recursively through Go alias declarations only, to the same canonical resource reference type declaration.
+
+An expression is canonically resource-typed if one canonical resource reference type declaration is determined for it in
+that way.
+
+For one canonically resource-typed expression:
+- if the expression is a string literal or a statically evaluable string constant, it is a resource reference candidate
+- if the expression cannot be statically evaluated, it remains resource-typed but is not a resolvable resource reference
+- for a top-level kind, the lookup key is `(resource kind, local resource name)`
+- for a scoped kind, the lookup key is `(resource kind, scope chain, local resource name)`
+- if a scoped kind does not have a statically available complete scope chain, the reference is one `scope-unknown`
+  reference
+
+### API-position scope bindings
+
+In this subsection, the callable site is the function declaration, method declaration, or interface method spec to which
+one resource-api-scope-binding comment with standardized meaning belongs.
+
+One resource-api-scope-binding comment has standardized meaning only if all of the following hold:
+- the target parameter position exists on the callable site
+- the target parameter position is not the variadic parameter position of the callable site
+- the target parameter type determines one canonical resource reference type declaration of one scoped kind
+- the source API position exists on the callable site
+- if the source API position is one parameter position, it is not the variadic parameter position of the callable site
+- the source API position determines either:
+  - one canonical resource reference type declaration of the direct parent kind of the target kind, or
+  - one handle-bearing type of that direct parent kind
+
+At one call that resolves to that callable site, the source API position is interpreted as follows:
+- if the source API position is `receiver`, the source expression is the call's receiver expression, whether explicit or
+  implicit
+- if the source API position is one parameter position, the source expression is the corresponding argument expression
+
+One resource-api-scope-binding comment contributes one explicit direct parent identity to its target argument position
+only if the source expression yields one exact resource identity of the target kind's direct parent kind under the
+resource semantics otherwise available at that source position.
+
+For this purpose, a source position may itself use explicit scope contributed by other resource-api-scope-binding
+comments on the same callable site, subject to the acyclicity rule above.
+
+If the target kind is multiply scoped, a resource-api-scope-binding comment contributes at most the direct parent
+identity. Any additional ancestor levels come from that direct parent identity's own scope chain, if available.
+
+If a target position receives one explicit direct parent identity from a resource-api-scope-binding comment, that
+identity is explicit scope for that target position.
+
+Example:
+
+```go
+//xgo:class:resource-api-scope-binding param.0 receiver
+func (p *SpriteImpl) SetCostume__0(costume SpriteCostumeName)
+
+//xgo:class:resource-api-scope-binding param.0 receiver
+//xgo:class:resource-api-scope-binding param.1 param.0
+func (p *SpriteImpl) SetCostumeAndFrame(costume SpriteCostumeName, frame SpriteCostumeFrameName)
+```
+
+If one call to `SetCostume__0` yields one exact `sprite` identity at its receiver position, the bound
+`SpriteCostumeName` argument position may use that identity as explicit scope.
+
+If one call to `SetCostumeAndFrame` yields one exact `sprite` identity at its receiver position, `param.0` may use that
+identity as explicit scope. If `param.0` then yields one exact `sprite.costume` identity, the bound
+`SpriteCostumeFrameName` argument position may use that identity as explicit scope.
+
+### Scoped owner inference
+
+If all of the following hold:
+- the current source position is inside a work classfile
+- the registered work base class declaration of that work file kind bears a resource comment for one top-level kind
+  `<parentKind>`
+- the referenced scoped kind has direct parent kind `<parentKind>`
+- no explicit scope is otherwise statically available
+
+then the statically available direct parent identity is the implied top-level resource of the containing work classfile.
+
+Example:
+- if the declaration of `SpriteImpl` bears `//xgo:class:resource sprite`
+- and the containing work classfile is registered by `class .spx SpriteImpl`
+- and `SpriteCostumeName` bears `//xgo:class:resource sprite.costume`
+- then a scoped `SpriteCostumeName` reference inside `Hero.spx` may use scope `(sprite, Hero)`
+
+If a resource-api-scope-binding comment contributes explicit scope to one target position, that explicit scope takes
+precedence over the narrow rule above for that target position.
+
+Receiver-bound owner inference, project auto-binding owner inference, and other framework-specific context rules remain
+framework-specific.
+
+If the narrow rule above does not apply, the scoped reference remains `scope-unknown`.
+
+The narrow rule above contributes at most one statically available parent identity. It does not by itself infer any
+additional ancestor levels for multiply scoped kinds.
+
+If a framework uses plain `string` parameters or resource-like values that do not reduce to canonical resource reference
+types, those positions are outside the standardized resource semantics of this specification.
+
+### Diagnostics
+
+A conforming implementation:
+- may emit a "resource not found" diagnostic only when its framework-specific discovery semantics are exact for the
+  analyzed project state
+- must not emit a "resource not found" diagnostic for dynamic expressions
+- must not emit a "resource not found" diagnostic for `scope-unknown` references
+- may emit a diagnostic for an empty resource name
+
+## Tool semantics
+
+### Hover
+
+When a source position resolves to a resource reference whose identity is present in the implementation's resource set,
+an implementation that provides hover must return information about the corresponding resource instance.
+
+### Completion
+
+When the target type at an input position resolves to a resource kind, an implementation that provides completion may
+base resource completion candidates on the implementation's resource set.
+
+For scoped kinds:
+- if the scope chain is known, completion must be filtered to that scope chain
+- if the scope chain is unknown, an implementation may suppress completion or provide degraded completion annotated with
+  scope information
+
+### Rename and references
+
+If an implementation supports rename or reference lookup for resources, resource identity must be based on
+`(framework registration identity, resource kind, optional scope chain, local resource name)` rather than raw string
+text.
+
+## Excluded semantics
+
+This specification intentionally does not standardize:
+- framework-specific API-position scope rules beyond explicit resource-api-scope-binding comments
+- API-position kind binding rules for positions that do not already depend on canonical resource reference types
+- implied resources from project classfiles
+- scoped classfile-implied resources beyond the work-classfile implication rule defined by this specification
+- how runtime parameters such as `run(...)` are mapped back into static analysis
+- the concrete encoding of preview URIs or editor-specific payloads
+- how failed DQL query fragment evaluations affect discovery completeness or diagnostics
+- one standardized completeness or exactness model for resource discovery

--- a/doc/classfile-spec.md
+++ b/doc/classfile-spec.md
@@ -13,13 +13,20 @@ There are two kinds of classfiles:
 The following terms are used throughout this document:
 - Class extension: the normalized classfile suffix used for framework lookup, e.g., `_app.gox` and `.gsh`
 - Class file stem: the filename without the class extension
+- Classfile project: the source tree rooted at the analyzed package directory and interpreted by the classfile mechanism
+- Project root directory: the root directory of one classfile project
+- Pack root: the directory named by one `pack` directive and resolved relative to one project root directory
+- Pack document: the logical merged configuration object derived from one pack root and its declared index filename
+- Project file kind: a framework file kind declared by one `project` directive and used for project classfiles
+- Work file kind: a framework file kind declared by one `class` directive and used for work classfiles
+- Project classfile: the framework file that represents the project-level class
+- Work classfile: a framework file that represents a non-project class within the same framework
 - Class type: the generated named type for a classfile
+- Base class: an embedded framework type declared by classfile metadata
+- Work prototype type: an exported type declared by classfile metadata and associated with one work file kind
 - Field declaration block: the unique top-level `var` declaration that is interpreted as class fields rather than
   package variables
 - Shadow entry: the synthetic function created from top-level statements
-- Project classfile: the framework file that represents the project-level class
-- Work classfile: a framework file that represents a non-project class within the same framework
-- Base class: an embedded framework type declared by classfile metadata
 
 ## File classification
 
@@ -172,9 +179,9 @@ Examples:
 - `get_p_#id_app.gox` has class file stem `get_p_#id` and normalized type name `get_p_id`
 
 Framework metadata may further transform the type name:
-- A project file whose class file stem is `main`, or a framework that has no explicit project file, uses the project
-  base-class name as its default class type name. A leading `*` on the base-class name is removed
-- A non-empty work-class `-prefix=` is prepended to the normalized work-file stem
+- A project classfile whose class file stem is `main`, or a framework that has no explicit project classfile, uses the
+  name of the base type named by the project base class as its default class type name
+- A non-empty `-prefix=` on a work file kind is prepended to the normalized class file stem of a work classfile
 - If neither of the previous rules applies and the class type name would otherwise equal one of the reserved names
   `init`, `main`, `go`, `goto`, `type`, `var`, `import`, `package`, `interface`, `struct`, `const`, `func`, `map`,
   `chan`, `for`, `if`, `else`, `switch`, `case`, `select`, `defer`, `range`, `return`, `break`, `continue`,
@@ -194,7 +201,7 @@ For a framework classfile, framework-added fields precede user fields.
 
 Framework-added fields are inserted in the following order:
 - For a project classfile, the embedded project base class
-- For a project classfile, each embedded work-class field requested by the `-embed` flag, in work-class declaration
+- For a project classfile, each embedded work class field requested by the `-embed` flag, in work file kind declaration
   order and lexicographic source-file path order
 - For a work classfile, the embedded work base class
 - For a work classfile, an embedded pointer to the project class type, if a project class type exists and its field name
@@ -359,18 +366,26 @@ The classfile loader recognizes the following module directives:
 ProjectDirective = "project" [ ProjectExt ExportedName ] PackagePath { PackagePath } .
 ClassDirective   = "class" { ClassDirectiveFlag } WorkExt ExportedName [ ExportedName ] .
 ImportDirective  = "import" [ ImportName ] PackagePath .
+PackDirective    = "pack" RelativeDirectoryPath PackIndexFile .
 ClassDirectiveFlag = "-embed" | "-prefix=" string_without_space .
+RelativeDirectoryPath = string_without_space .
+PackIndexFile    = string_without_space .
 ```
 
-Every `class` or `import` directive belongs to the most recent preceding `project` directive.
+`RelativeDirectoryPath` is one relative directory path token with no spaces.
 
-A project group consists of one `project` directive together with all `class` and `import` directives that belong to it.
+`PackIndexFile` is one plain file name token with no spaces.
 
-The first package path of a `project` directive is the framework package used to resolve any base-class symbols named by
-that project group.
+Every `class`, `import`, or `pack` directive belongs to the most recent preceding `project` directive.
 
-Any additional package paths participate in implicit framework-package export lookup but are not searched for
-base-class symbols.
+A project group consists of one `project` directive together with all `class`, `import`, and `pack` directives that
+belong to it.
+
+The first package path of a `project` directive is the framework package used to resolve the project base class, each
+work base class, and each work prototype type named by that project group.
+
+Any additional package paths participate in implicit framework-package export lookup but are not searched for those
+symbols.
 
 ### Extension forms and normalization
 
@@ -382,10 +397,9 @@ Both forms are part of the classfile mechanism. Neither form is a compatibility 
 
 For newly defined framework registrations, `_[class].gox` is the recommended form.
 
-This recommendation does not constrain the built-in registrations defined above.
+The built-in registrations defined above remain valid as written.
 
-This specification defines file classification and compilation semantics for both forms. It does not require auxiliary
-tools to recognize arbitrary non-`.gox` class extensions automatically.
+Auxiliary tool behavior for arbitrary non-`.gox` class extensions is implementation-defined.
 
 The textual extension token accepted by `project` and `class` directives may be written with a leading `*` and, for
 projects, may also be written with a leading `main`.
@@ -403,18 +417,22 @@ For each `project` directive:
 - If `ProjectExt` and `ExportedName` are present, the directive defines a project file kind and names the project base
   class
 - If `ProjectExt` and `ExportedName` are omitted, the directive defines no project file kind or project base class and
-  still defines the package lookup set and the project group to which subsequent `class` and `import` directives belong
+  still defines the package lookup set and the project group to which subsequent `class`, `import`, and `pack`
+  directives belong
 - When a project base class is named, the first package path is the package from which that symbol is resolved
 - A project base-class name may be written with a leading `*`, in which case the generated project class embeds a
   pointer to the named base type rather than the base type itself
 
 For each `class` directive:
-- The exported symbol names the work base class
+- The exported symbol names the work base class and is resolved from the framework package of the containing project
+  group
 - The optional final exported symbol is the work prototype type
-- If a project group declares more than one work class kind, every work class in that group must declare a prototype
-  type
+- If a project group declares more than one work file kind, every work file kind in that group must declare a work
+  prototype type
+- When a work prototype type is named, the work prototype type symbol is resolved from the framework package of the
+  containing project group
+- `-embed` causes the project class type to embed a field for each generated work class instance of that work file kind
 - `-prefix=` prepends the given string to every generated work class type name
-- `-embed` causes the project class type to embed a field for each generated work class instance of that work kind
 
 For each `import` directive:
 - The imported package becomes available to classfiles as an auto-imported package name
@@ -422,7 +440,16 @@ For each `import` directive:
 - If multiple `import` directives in the same project group resolve to the same auto-import name, the last directive
   wins
 
-## Project and work-class assembly
+For each `pack` directive:
+- The project group may declare at most one `pack` directive
+- The directory path is resolved relative to the project root directory of the analyzed classfile project
+- The directory path must not contain any `..` path component
+- The index filename determines the root configuration filename of the pack root and the child configuration filename
+  expected at each descendant directory level
+- The index filename must not contain `/` or `\`
+- The index filename must end in one of `.json`, `.yml`, or `.yaml`
+
+## Project and work class assembly
 
 A test framework registration is a framework registration whose project extension has the suffix `test.gox`.
 
@@ -434,35 +461,35 @@ For each framework registration, a package may contain at most one explicit proj
 
 It is an error for a package to contain more than one explicit project classfile for the same framework registration.
 
-If a framework registration provides a project base class but the package contains no explicit project file for that
-framework, the compiler still synthesizes a default project class type.
+If a framework registration provides a project base class but the package contains no explicit project classfile for
+that framework, the compiler still synthesizes a default project class type.
 
 The synthesized project class has no source file of its own. Its type name is derived by the project type-naming rules
 described earlier.
 
-### Work-instance assembly for project `Main`
+### Work instance assembly for project `Main`
 
 For every non-test framework registration that provides a project base class, the compiler generates a project method
 named `Main` on the project class type. The project base class is therefore required to provide a method named `Main`.
-The generated project method constructs work-class instances and forwards them to the embedded project base-class method
+The generated project method constructs work class instances and forwards them to the embedded project base-class method
 `Main`.
 
 The grouping rule is:
-- If the framework has exactly one work class kind and that `Main` parameter is variadic, all work files of that kind
-  are passed as variadic arguments
-- Otherwise, work files are grouped by their declared prototype type and passed as slices in `Main` parameter order
+- If the framework has exactly one work file kind and that `Main` parameter is variadic, all work files of that kind are
+  passed as variadic arguments
+- Otherwise, work files are grouped by their declared work prototype type and passed as slices in `Main` parameter order
 
-The project `Main` method constructs one fresh work-class instance for each work file in the package. When `-embed` is
-present on a work class declaration, the freshly created work instance is also assigned into the corresponding embedded
-field on the project instance before the project `Main` call.
+The project `Main` method constructs one fresh work class instance for each work file in the package. When `-embed` is
+present on the corresponding `class` directive, the freshly created work instance is also assigned into the
+corresponding embedded field on the project instance before the project `Main` call.
 
 ## Synthesized helper methods
 
-The compiler may synthesize additional work-class methods when the declared work prototype requires them.
+The compiler may synthesize additional work class methods when the declared work prototype type requires them.
 
 ### `Classfname`
 
-If the work prototype contains a method named `Classfname`, the compiler generates:
+If the work prototype type contains a method named `Classfname`, the compiler generates:
 
 ```xgo
 func (this *T) Classfname() string
@@ -476,9 +503,9 @@ Examples:
 
 ### `Classclone`
 
-If the work prototype contains a method named `Classclone`, the compiler generates a shallow-clone method named
-`Classclone` with no parameters other than the receiver. Its result list is adopted from the prototype's `Classclone`
-declaration.
+If the work prototype type contains a method named `Classclone`, the compiler generates a shallow-clone method named
+`Classclone` with no parameters other than the receiver. Its result list is adopted from the work prototype type's
+`Classclone` declaration.
 
 The generated implementation copies `*this` by value into a temporary variable and returns the address of that temporary
 value.
@@ -492,7 +519,7 @@ If one exists, no class-based package `main` is synthesized.
 
 If none exists, the compiler selects a class entrypoint as follows:
 1. It considers only non-test framework registrations
-2. Among framework project groups, it prefers a unique project group whose explicit project file has a shadow entry
+2. Among framework project groups, it prefers a unique project group whose explicit project classfile has a shadow entry
 3. If no such group exists, it prefers a unique remaining project group, including one that is represented only by a
    synthesized default project class
 4. If no project group is selected, it selects the unique normal classfile that has a shadow entry, if exactly one
@@ -506,6 +533,40 @@ func main() { new(T).Main() }
 
 If no class type is selected, the compiler generates an empty `main` function unless automatic main generation is
 disabled in compiler configuration.
+
+## Pack roots and pack documents
+
+One active project group may derive zero or one pack document from one classfile project.
+
+If one active project group declares one `pack` directive, its pack root is the resolved directory named by that
+directive.
+
+Active project groups do not share pack roots or pack documents. Each active project group derives its own pack
+document independently from its own `pack` directive, if any.
+
+For one active project group whose `pack` directive resolves to one pack root `R` and one index filename `F`, the
+corresponding pack document is one logical object tree derived as follows:
+- `R/F` is parsed as one object value
+- each descendant directory of `R` that contains `F` contributes one child object
+- each such child object is parsed from that descendant `F` and merged into the root object at the relative
+  directory path from `R`, creating intermediate objects as needed
+- directories that do not contain `F` contribute no object of their own
+- files other than contributing `F` files are outside the standardized pack-document model
+
+If the project group declares no `pack` directive, no standardized pack document is derived for that project group.
+
+If `R/F` does not exist, does not parse as one object value, or if one merge would overwrite an existing key at the
+same object level, no standardized pack document is derived for that project group.
+
+The project files remain the source of truth. Each pack document is derived from one analyzed project state and one
+active project group.
+
+An implementation may materialize one pack document as one generated sibling file of its root configuration file named:
+- `index_pack.json` if `F` ends in `.json`
+- `index_pack.yml` if `F` ends in `.yml`
+- `index_pack.yaml` if `F` ends in `.yaml`
+
+Its enablement mechanism is implementation-defined.
 
 ## Compatibility
 
@@ -524,5 +585,5 @@ Accordingly:
   package semantics
 - Package initialization order for ordinary package variables is unchanged
 
-The classfile mechanism therefore adds a source-level lowering rule. It does not add a new runtime object model beyond
-what is produced by the lowered Go code.
+The classfile mechanism therefore adds a source-level lowering rule and preserves the ordinary runtime object model
+produced by the lowered Go code.

--- a/doc/classfile-spec.md
+++ b/doc/classfile-spec.md
@@ -2,7 +2,7 @@
 
 This document defines the syntax and semantics of XGo classfiles.
 
-A classfile is a source file that is compiled as a generated class type plus a set of generated methods and helper glue.
+A classfile is a source file compiled through classfile-specific type, method, and entrypoint lowering.
 
 There are two kinds of classfiles:
 - A normal classfile, which is an otherwise unregistered `.gox` file
@@ -13,13 +13,27 @@ There are two kinds of classfiles:
 The following terms are used throughout this document:
 - Class extension: the normalized classfile suffix used for framework lookup, e.g., `_app.gox` and `.gsh`
 - Class file stem: the filename without the class extension
-- Class type: the generated named type for a classfile
-- Field declaration block: the unique top-level `var` declaration that is interpreted as class fields rather than
-  package variables
-- Shadow entry: the synthetic function created from top-level statements
+- Classfile project: the source tree rooted at the analyzed package directory and interpreted by the classfile mechanism
+- Framework registration: one project group loaded into the classfile registry
+- Active project group: a framework registration under which at least one source file in the analyzed classfile project
+  is recognized as a framework classfile
+- Project root directory: the root directory of one classfile project
+- Pack root: the directory named by one `pack` directive and resolved relative to one project root directory
+- Pack document: the logical merged configuration object derived from one pack root and its declared index filename
+- Flat project group: a project group declared with `project -flat`
+- Project file kind: a framework file kind declared by one `project` directive and used for project classfiles and, in a
+  flat project group, project fragments
+- Work file kind: a framework file kind declared by one `class` directive and used for work classfiles
 - Project classfile: the framework file that represents the project-level class
 - Work classfile: a framework file that represents a non-project class within the same framework
+- Project fragment classfile: a framework classfile in a flat project group that is not the project classfile and that
+  contributes to the shared project class type
+- Class type: a generated named type for one classfile or one flat project group
 - Base class: an embedded framework type declared by classfile metadata
+- Work prototype type: an exported type declared by classfile metadata and associated with one work file kind
+- Field declaration block: a top-level `var` declaration that is interpreted as class fields rather than package
+  variables
+- Shadow entry: the synthetic function created from top-level statements
 
 ## File classification
 
@@ -49,24 +63,31 @@ If the second rule applies, the file is a normal classfile.
 
 If the first rule applies, the file is a framework classfile.
 
-### Project and work classification
+### Project, work, and fragment classification
 
 Each recognized class extension belongs to exactly one framework registration.
 
-A recognized file is a project classfile if the registration marks it as a project file for the pair
-`(class extension, filename)`. Otherwise it is a work classfile.
+A recognized file in a non-flat project group is a project classfile if the registration marks it as a project file for
+the pair `(class extension, filename)`. Otherwise it is a work classfile.
 
-A recognized file is classified as follows:
+A recognized file in a non-flat project group is classified as follows:
 - If a project extension and a work extension are different, every file whose normalized class extension equals the
   project extension is a project file
 - If a project extension and a work extension are the same, only the filename `main` plus that extension is a project
   file and all other files with the same extension are work files
+
+In a flat project group:
+- The filename `main` plus the project extension is the project classfile
+- Every other recognized file with the project extension is a project fragment classfile
+- No file is a work classfile
 
 Examples:
 - Under metadata where the project extension and work extension are both `_case.gox`, `main_case.gox` is a project file
   and `foo_case.gox` is a work file
 - Under metadata where `_app.gox` is the project extension and `_cmd.gox` is the work extension, `demo_app.gox` is a
   project file and `list_cmd.gox` is a work file
+- Under metadata `project -flat .spx Game example.com/framework`, `main.spx` is the project file and `hero.spx` is a
+  project fragment
 
 ## Source form
 
@@ -101,19 +122,14 @@ as `var x = 1`, become part of the shadow entry rather than remaining top-level 
 
 ### Field declaration block
 
-For the purposes of class lowering, at most one top-level `var` declaration is interpreted as the field declaration
-block.
+A classfile may contain at most one top-level `var` declaration. If present, it must precede every top-level function
+declaration and is the field declaration block.
 
-The field declaration block is identified semantically as follows:
-- The declaration must be a top-level `var` declaration in the file's declaration list
-- Every preceding top-level declaration, if any, must be an `import`, `const`, or `type` declaration
-- It must be the first top-level `var` declaration satisfying those conditions
+The field declaration block does not introduce package variables. Instead, it declares fields of the generated class
+type.
 
-That declaration does not introduce package variables. Instead, it declares fields of the generated class type.
-
-All other top-level `var` declarations follow ordinary variable-declaration rules. If they occur before the shadow entry
-begins, they are package-level variables. If they occur after the shadow entry begins, they are local declaration
-statements inside that entry method.
+A `var` declaration parsed after the shadow entry begins is a local declaration statement inside that entry method, not
+a top-level declaration.
 
 This specification defines embedded-field syntax only for the field declaration block.
 
@@ -157,9 +173,15 @@ Within the field declaration block:
 
 ### Type naming
 
-For every classfile, the compiler generates one named class type.
+The compiler generates:
+- One named class type for each normal classfile
+- One named class type for each project or work classfile in a non-flat project group
+- One shared named project class type for each active flat project group
 
-The initial class type name is derived from the class file stem.
+A project fragment does not generate a distinct class type.
+
+The initial class type name is derived from the class file stem of the corresponding classfile. For a flat project
+group, it is derived from the project classfile.
 
 The class file stem is normalized as follows:
 - `:` is removed
@@ -172,9 +194,9 @@ Examples:
 - `get_p_#id_app.gox` has class file stem `get_p_#id` and normalized type name `get_p_id`
 
 Framework metadata may further transform the type name:
-- A project file whose class file stem is `main`, or a framework that has no explicit project file, uses the project
-  base-class name as its default class type name. A leading `*` on the base-class name is removed
-- A non-empty work-class `-prefix=` is prepended to the normalized work-file stem
+- A project classfile whose class file stem is `main`, or a framework that has no explicit project classfile, uses the
+  name of the base type named by the project base class as its default class type name
+- A non-empty `-prefix=` on a work file kind is prepended to the normalized class file stem of a work classfile
 - If neither of the previous rules applies and the class type name would otherwise equal one of the reserved names
   `init`, `main`, `go`, `goto`, `type`, `var`, `import`, `package`, `interface`, `struct`, `const`, `func`, `map`,
   `chan`, `for`, `if`, `else`, `switch`, `case`, `select`, `defer`, `range`, `return`, `break`, `continue`,
@@ -188,19 +210,26 @@ The underlying type of every class type is a struct type.
 
 For a normal classfile, the struct fields are the user fields declared in the field declaration block, in source order.
 
-For a framework classfile, framework-added fields precede user fields.
+For a class type in a non-flat project group, framework-added fields precede the user fields declared in that
+classfile's field declaration block.
+
+For a flat project group, framework-added fields precede all user fields contributed by its project classfile and
+project fragments. The project classfile contributes first. Project fragments contribute in lexicographic source-file
+path order. Fields within each field declaration block retain source order.
 
 ### Framework-added fields
 
 Framework-added fields are inserted in the following order:
 - For a project classfile, the embedded project base class
-- For a project classfile, each embedded work-class field requested by the `-embed` flag, in work-class declaration
+- For a project classfile, each embedded work class field requested by the `-embed` flag, in work file kind declaration
   order and lexicographic source-file path order
 - For a work classfile, the embedded work base class
 - For a work classfile, an embedded pointer to the project class type, if a project class type exists and its field name
   does not conflict with an already-present field name
 
-User fields from the field declaration block are appended after all framework-added fields.
+The embedded project base class is the only framework-added field in a flat project class type.
+
+User fields are appended after all framework-added fields in the order defined above.
 
 It is an error for two generated fields of the same class type to have the same field name.
 
@@ -208,8 +237,8 @@ It is an error for two generated fields of the same class type to have the same 
 
 ### Implicit receiver rewriting
 
-In a classfile, every top-level function declaration without an explicit receiver is rewritten as a method on the
-generated class type.
+In a classfile, every top-level function declaration without an explicit receiver is rewritten as a method on the class
+type associated with that classfile. For a project fragment, the associated class type is the shared project class type.
 
 The injected receiver is:
 - Named `this`
@@ -235,8 +264,8 @@ The classfile parser also accepts the following classfile-only `FuncDecl` form:
 StaticMethodDecl = "func" "." identifier Signature [ FunctionBody ] .
 ```
 
-This form declares a static method associated with the generated class type. Its further lowering follows the ordinary
-XGo static-method machinery.
+This form declares a static method on the class type associated with that classfile. Its further lowering follows the
+ordinary XGo static-method machinery.
 
 ### Shadow entry
 
@@ -245,22 +274,27 @@ Top-level statements are not compiled as package-level statements.
 Instead, they are wrapped into a synthetic function with an initially empty parameter list, called the shadow entry.
 After classfile lowering, the shadow entry is renamed as follows:
 - `MainEntry` for a project classfile
-- `Main` for any other classfile
+- `Main` for a work or normal classfile
+- an implementation-defined unexported name for a project fragment
 
-If a framework classfile has no explicit top-level statement sequence, the compiler still synthesizes an empty shadow
-entry with the same name. This ensures that framework entry methods always exist.
+If a project or work classfile has no explicit top-level statement sequence, the compiler still synthesizes an empty
+shadow entry with the same name. This ensures that those framework entry methods always exist.
+
+A project fragment without top-level statements has no shadow entry.
 
 For a normal classfile, no empty shadow entry is synthesized. A normal classfile without top-level statements therefore
 has no synthetic `Main` method.
 
 ### Base-entry forwarding
 
-If a synthetic `Main` or `MainEntry` method is created for a framework classfile, and the embedded base class declares a
-method with the same name, the synthetic method adopts that base method's parameter list and result list, with the
-classfile receiver `*T` replacing the base receiver.
+If a synthetic `Main` or `MainEntry` method is created for a project or work classfile, and the embedded base class
+declares a method with the same name, the synthetic method adopts that base method's parameter list and result list,
+with the classfile receiver `*T` replacing the base receiver.
 
 The generated body forwards the incoming arguments to the embedded base method before executing any user-written
 top-level statements.
+
+A project fragment shadow entry always has no parameters and no results. It does not forward to a base method.
 
 ### Execution order inside a synthetic entry method
 
@@ -271,6 +305,9 @@ If a synthetic `Main` or `MainEntry` method is generated, its body executes in t
 
 This order is fixed.
 
+A project fragment shadow entry executes only its user-written top-level statements and does not call `XGo_Init`. Any
+automatic initialization of the shared project class type occurs through its synthetic `MainEntry` method.
+
 If the adopted method signature has result parameters, the resulting body is checked under ordinary Go control-flow
 rules for that signature after lowering.
 
@@ -278,15 +315,18 @@ rules for that signature after lowering.
 
 ### `XGo_Init` generation
 
-If at least one field in the field declaration block has an initializer, the compiler generates a method:
+If at least one user field of a class type has an initializer, the compiler generates a method:
 
 ```xgo
 func (this *T) XGo_Init() *T
 ```
 
-The generated method assigns all field initializers in field-declaration order and then returns `this`.
+The generated method assigns all field initializers in generated field order and then returns `this`.
 
-If the field declaration block contains no initializers, no `XGo_Init` method is generated.
+For a flat project class type, this includes initializers contributed by the project classfile and all project
+fragments.
+
+If the class type has no user field initializers, no `XGo_Init` method is generated.
 
 ### What `XGo_Init` does not do
 
@@ -346,7 +386,7 @@ project _test.gox App github.com/goplus/xgo/test testing
 class _test.gox Case
 ```
 
-A built-in registration is active without any module declaration.
+A built-in registration is loaded into the classfile registry without any module declaration.
 
 Built-in registrations participate in file classification, lowering, and package assembly exactly as if they were loaded
 from module metadata.
@@ -356,21 +396,33 @@ from module metadata.
 The classfile loader recognizes the following module directives:
 
 ```ebnf
-ProjectDirective = "project" [ ProjectExt ExportedName ] PackagePath { PackagePath } .
-ClassDirective   = "class" { ClassDirectiveFlag } WorkExt ExportedName [ ExportedName ] .
-ImportDirective  = "import" [ ImportName ] PackagePath .
-ClassDirectiveFlag = "-embed" | "-prefix=" string_without_space .
+ProjectDirective      = "project" [ "-flat" ] [ ProjectExt ExportedName ] PackagePath { PackagePath } .
+ClassDirective        = "class" { ClassDirectiveFlag } WorkExt ExportedName [ ExportedName ] .
+ImportDirective       = "import" [ ImportName ] PackagePath .
+PackDirective         = "pack" RelativeDirectoryPath PackIndexFile .
+ClassDirectiveFlag    = "-embed" | "-prefix=" string_without_space .
+RelativeDirectoryPath = string_without_space .
+PackIndexFile         = string_without_space .
 ```
 
-Every `class` or `import` directive belongs to the most recent preceding `project` directive.
+`RelativeDirectoryPath` is one relative directory path token with no spaces.
 
-A project group consists of one `project` directive together with all `class` and `import` directives that belong to it.
+`PackIndexFile` is one plain file name token with no spaces.
 
-The first package path of a `project` directive is the framework package used to resolve any base-class symbols named by
-that project group.
+Every `class`, `import`, or `pack` directive belongs to the most recent preceding `project` directive.
 
-Any additional package paths participate in implicit framework-package export lookup but are not searched for
-base-class symbols.
+A project group consists of one `project` directive together with all `class`, `import`, and `pack` directives that
+belong to it.
+
+One framework registration is active relative to one analyzed classfile project if at least one source file in that
+project is recognized under the registration. An inactive registration does not cause project class synthesis, package
+entrypoint synthesis, or pack-document derivation.
+
+The first package path of a `project` directive is the framework package used to resolve the project base class, each
+work base class, and each work prototype type named by that project group.
+
+Any additional package paths participate in implicit framework-package export lookup but are not searched for those
+symbols.
 
 ### Extension forms and normalization
 
@@ -382,10 +434,9 @@ Both forms are part of the classfile mechanism. Neither form is a compatibility 
 
 For newly defined framework registrations, `_[class].gox` is the recommended form.
 
-This recommendation does not constrain the built-in registrations defined above.
+The built-in registrations defined above remain valid as written.
 
-This specification defines file classification and compilation semantics for both forms. It does not require auxiliary
-tools to recognize arbitrary non-`.gox` class extensions automatically.
+Auxiliary tool behavior for arbitrary non-`.gox` class extensions is implementation-defined.
 
 The textual extension token accepted by `project` and `class` directives may be written with a leading `*` and, for
 projects, may also be written with a leading `main`.
@@ -403,18 +454,27 @@ For each `project` directive:
 - If `ProjectExt` and `ExportedName` are present, the directive defines a project file kind and names the project base
   class
 - If `ProjectExt` and `ExportedName` are omitted, the directive defines no project file kind or project base class and
-  still defines the package lookup set and the project group to which subsequent `class` and `import` directives belong
+  still defines the package lookup set and the project group to which subsequent `class`, `import`, and `pack`
+  directives belong
 - When a project base class is named, the first package path is the package from which that symbol is resolved
 - A project base-class name may be written with a leading `*`, in which case the generated project class embeds a
   pointer to the named base type rather than the base type itself
 
+The `-flat` flag requires `ProjectExt` and `ExportedName` and declares the containing project group to be flat. The
+project extension of a flat project group must not be `.gox`.
+
+A flat project group has one project file kind, has no work file kinds, and must not contain a `class` directive.
+
 For each `class` directive:
-- The exported symbol names the work base class
+- The exported symbol names the work base class and is resolved from the framework package of the containing project
+  group
 - The optional final exported symbol is the work prototype type
-- If a project group declares more than one work class kind, every work class in that group must declare a prototype
-  type
+- If a project group declares more than one work file kind, every work file kind in that group must declare a work
+  prototype type
+- When a work prototype type is named, the work prototype type symbol is resolved from the framework package of the
+  containing project group
+- `-embed` causes the project class type to embed a field for each generated work class instance of that work file kind
 - `-prefix=` prepends the given string to every generated work class type name
-- `-embed` causes the project class type to embed a field for each generated work class instance of that work kind
 
 For each `import` directive:
 - The imported package becomes available to classfiles as an auto-imported package name
@@ -422,7 +482,16 @@ For each `import` directive:
 - If multiple `import` directives in the same project group resolve to the same auto-import name, the last directive
   wins
 
-## Project and work-class assembly
+For each `pack` directive:
+- The project group may declare at most one `pack` directive
+- The directory path is resolved relative to the project root directory of the analyzed classfile project
+- The directory path must not contain any `..` path component
+- The index filename determines the root configuration filename of the pack root and the child configuration filename
+  expected at each descendant directory level
+- The index filename must not contain `/` or `\`
+- The index filename must end in one of `.json`, `.yml`, or `.yaml`
+
+## Framework class assembly
 
 A test framework registration is a framework registration whose project extension has the suffix `test.gox`.
 
@@ -430,39 +499,65 @@ All other framework registrations are non-test framework registrations.
 
 ### Default project synthesis
 
-For each framework registration, a package may contain at most one explicit project classfile.
+For each active non-flat project group, a package may contain at most one explicit project classfile.
 
 It is an error for a package to contain more than one explicit project classfile for the same framework registration.
 
-If a framework registration provides a project base class but the package contains no explicit project file for that
-framework, the compiler still synthesizes a default project class type.
+If an active non-flat project group provides a project base class but the package contains no explicit project
+classfile, the compiler still synthesizes a default project class type.
 
 The synthesized project class has no source file of its own. Its type name is derived by the project type-naming rules
 described earlier.
 
-### Work-instance assembly for project `Main`
+An active flat project group must contain exactly one project classfile. A flat project group never receives a
+synthesized default project class.
 
-For every non-test framework registration that provides a project base class, the compiler generates a project method
-named `Main` on the project class type. The project base class is therefore required to provide a method named `Main`.
-The generated project method constructs work-class instances and forwards them to the embedded project base-class method
-`Main`.
+### Work instance assembly for project `Main`
+
+For every active non-test, non-flat project group that provides a project base class, the compiler generates a project
+method named `Main` on the project class type. The project base class is therefore required to provide a method named
+`Main`. The generated project method constructs work class instances and forwards them to the embedded project
+base-class method `Main`.
 
 The grouping rule is:
-- If the framework has exactly one work class kind and that `Main` parameter is variadic, all work files of that kind
-  are passed as variadic arguments
-- Otherwise, work files are grouped by their declared prototype type and passed as slices in `Main` parameter order
+- If the framework has exactly one work file kind and that `Main` parameter is variadic, all work files of that kind are
+  passed as variadic arguments
+- Otherwise, work files are grouped by their declared work prototype type and passed as slices in `Main` parameter order
 
-The project `Main` method constructs one fresh work-class instance for each work file in the package. When `-embed` is
-present on a work class declaration, the freshly created work instance is also assigned into the corresponding embedded
-field on the project instance before the project `Main` call.
+The project `Main` method constructs one fresh work class instance for each work file in the package. When `-embed` is
+present on the corresponding `class` directive, the freshly created work instance is also assigned into the
+corresponding embedded field on the project instance before the project `Main` call.
+
+### Flat project assembly for project `Main`
+
+For every active non-test flat project group, the compiler generates a project method named `Main` on the shared project
+class type.
+
+The project base class must provide a method named `Main` whose parameter list contains exactly one non-variadic
+parameter of type `func()` and whose result list is empty.
+
+If at least one project fragment exists, the compiler synthesizes one work callback method:
+
+```xgo
+func (this *T) _xgo_WorkMain()
+```
+
+The callback invokes the shadow entry of each fragment that has top-level statements in lexicographic source-file path
+order. The generated project `Main` passes the bound method value `this._xgo_WorkMain` to the embedded project
+base-class method `Main`.
+
+If no project fragment exists, no `_xgo_WorkMain` method is generated and the generated project `Main` passes `nil`.
+
+All fragment shadow entries and `_xgo_WorkMain` use the same project instance as their receiver. Project fragments do
+not construct work class instances.
 
 ## Synthesized helper methods
 
-The compiler may synthesize additional work-class methods when the declared work prototype requires them.
+The compiler may synthesize additional work class methods when the declared work prototype type requires them.
 
 ### `Classfname`
 
-If the work prototype contains a method named `Classfname`, the compiler generates:
+If the work prototype type contains a method named `Classfname`, the compiler generates:
 
 ```xgo
 func (this *T) Classfname() string
@@ -476,9 +571,9 @@ Examples:
 
 ### `Classclone`
 
-If the work prototype contains a method named `Classclone`, the compiler generates a shallow-clone method named
-`Classclone` with no parameters other than the receiver. Its result list is adopted from the prototype's `Classclone`
-declaration.
+If the work prototype type contains a method named `Classclone`, the compiler generates a shallow-clone method named
+`Classclone` with no parameters other than the receiver. Its result list is adopted from the work prototype type's
+`Classclone` declaration.
 
 The generated implementation copies `*this` by value into a temporary variable and returns the address of that temporary
 value.
@@ -491,11 +586,11 @@ exists.
 If one exists, no class-based package `main` is synthesized.
 
 If none exists, the compiler selects a class entrypoint as follows:
-1. It considers only non-test framework registrations
-2. Among framework project groups, it prefers a unique project group whose explicit project file has a shadow entry
-3. If no such group exists, it prefers a unique remaining project group, including one that is represented only by a
-   synthesized default project class
-4. If no project group is selected, it selects the unique normal classfile that has a shadow entry, if exactly one
+1. Among active non-test framework project groups, it prefers a unique project group whose explicit project classfile
+   has a shadow entry
+2. If no such group exists, it prefers a unique remaining active non-test project group, including one that is
+   represented only by a synthesized default project class
+3. If no project group is selected, it selects the unique normal classfile that has a shadow entry, if exactly one
    exists
 
 If this process selects a class type `T`, the compiler generates:
@@ -506,6 +601,42 @@ func main() { new(T).Main() }
 
 If no class type is selected, the compiler generates an empty `main` function unless automatic main generation is
 disabled in compiler configuration.
+
+## Pack roots and pack documents
+
+One active project group may derive zero or one pack document from one classfile project.
+
+If one active project group declares one `pack` directive, its pack root is the resolved directory named by that
+directive.
+
+Active project groups do not share pack roots or pack documents. Each active project group derives its own pack document
+independently from its own `pack` directive, if any.
+
+For one active project group whose `pack` directive resolves to one pack root `R` and one index filename `F`, the
+corresponding pack document is one logical object tree derived as follows:
+- `R/F` is parsed as one object value
+- each descendant directory of `R` that contains `F` contributes one child object
+- each such child object is parsed from that descendant `F` and merged into the root object at the relative directory
+  path from `R`, creating intermediate objects as needed
+- a contributing empty object remains present at its relative directory path
+- directories that do not contain `F` contribute no object of their own
+- files other than contributing `F` files are outside the standardized pack-document model
+
+If the project group declares no `pack` directive, no standardized pack document is derived for that project group.
+
+If `R/F` does not exist, if `R/F` or any contributing descendant `F` cannot be read or parsed as one object value, or if
+one merge would overwrite an existing key at the same object level, no standardized pack document is derived for that
+project group.
+
+The project files remain the source of truth. Each pack document is derived from one analyzed project state and one
+active project group.
+
+An implementation may materialize one pack document as one generated sibling file of its root configuration file named:
+- `index_pack.json` if `F` ends in `.json`
+- `index_pack.yml` if `F` ends in `.yml`
+- `index_pack.yaml` if `F` ends in `.yaml`
+
+Its enablement mechanism is implementation-defined.
 
 ## Compatibility
 
@@ -520,9 +651,9 @@ ordinary static-method helpers.
 
 Accordingly:
 - Composite literals for class types follow ordinary struct literal rules after lowering
-- Ordinary package variables, constants, types, and explicit methods declared in the same package follow ordinary
-  package semantics
+- Package variables declared by non-classfile source files, and constants, types, and explicit methods declared in the
+  same package, follow ordinary package semantics
 - Package initialization order for ordinary package variables is unchanged
 
-The classfile mechanism therefore adds a source-level lowering rule. It does not add a new runtime object model beyond
-what is produced by the lowered Go code.
+The classfile mechanism therefore adds a source-level lowering rule and preserves the ordinary runtime object model
+produced by the lowered Go code.


### PR DESCRIPTION
Define framework resource kinds, pack-document discovery, typed scope bindings, and static tool semantics for classfile resources.

Specify active project groups and flat project lowering, including shared project types, fragment ordering, field initialization, and callback assembly.

Clarify pack-document merging and DQL query fragments relative to implicit discovery roots.

Fixes #2704
Updates #2719
Updates #2802
