### PR TITLE
x/format: new XGoStyleSource/XGoStyle

### DIFF
--- a/cmd/internal/gopfmt/fmt.go
+++ b/cmd/internal/gopfmt/fmt.go
@@ -69,7 +69,7 @@ func gopfmt(path string, class, smart, mvgo bool) (err error) {
 	}
 	var target []byte
 	if smart {
-		target, err = xformat.GopstyleSource(src, path)
+		target, err = xformat.XGoStyleSource(src, class, path)
 	} else {
 		if !mvgo && filepath.Ext(path) == ".go" {
 			fset := token.NewFileSet()

--- a/x/format/gopstyle.go
+++ b/x/format/gopstyle.go
@@ -30,15 +30,19 @@ import (
 
 // -----------------------------------------------------------------------------
 
-func GopstyleSource(src []byte, filename ...string) (ret []byte, err error) {
+func XGoStyleSource(src []byte, class bool, filename ...string) (ret []byte, err error) {
 	var fname string
 	if filename != nil {
 		fname = filename[0]
 	}
 	fset := token.NewFileSet()
+	mode := parser.ParseComments
+	if class {
+		mode |= parser.ParseXGoClass
+	}
 	var f *ast.File
-	if f, err = parser.ParseFile(fset, fname, src, parser.ParseComments); err == nil {
-		Gopstyle(f)
+	if f, err = parser.ParseFile(fset, fname, src, mode); err == nil {
+		XGoStyle(f)
 		var buf bytes.Buffer
 		if err = format.Node(&buf, fset, f); err == nil {
 			ret = buf.Bytes()
@@ -47,9 +51,14 @@ func GopstyleSource(src []byte, filename ...string) (ret []byte, err error) {
 	return
 }
 
+// Deprecated: Use XGoStyleSource instead.
+func GopstyleSource(src []byte, filename ...string) (ret []byte, err error) {
+	return XGoStyleSource(src, false, filename...)
+}
+
 // -----------------------------------------------------------------------------
 
-func Gopstyle(file *ast.File) {
+func XGoStyle(file *ast.File) {
 	if identEqual(file.Name, "main") {
 		file.NoPkgDecl = true
 	}
@@ -67,6 +76,11 @@ func Gopstyle(file *ast.File) {
 		}
 	}
 	formatFile(file)
+}
+
+// Deprecated: Use XGoStyle instead.
+func Gopstyle(file *ast.File) {
+	XGoStyle(file)
 }
 
 func findFuncDecl(decls []ast.Decl, name string) (int, *ast.FuncDecl) {

--- a/x/format/gopstyle_test.go
+++ b/x/format/gopstyle_test.go
@@ -22,7 +22,19 @@ import (
 
 func testFormat(t *testing.T, name string, src, expect string) {
 	t.Run(name, func(t *testing.T) {
-		result, err := GopstyleSource([]byte(src), name)
+		result, err := XGoStyleSource([]byte(src), false, name)
+		if err != nil {
+			t.Fatal("format.Source failed:", err)
+		}
+		if ret := string(result); ret != expect {
+			t.Fatalf("%s => Expect:\n%s\n=> Got:\n%s\n", name, expect, ret)
+		}
+	})
+}
+
+func testFormatClass(t *testing.T, name string, src, expect string) {
+	t.Run(name, func(t *testing.T) {
+		result, err := XGoStyleSource([]byte(src), true, name)
 		if err != nil {
 			t.Fatal("format.Source failed:", err)
 		}
@@ -531,5 +543,26 @@ demo4 100, func(n1, n2 int) (a, b int) {
 	println a, b
 	return n1 + n2, n1 - n2
 }, 100
+`)
+}
+
+func TestClass(t *testing.T) {
+	testFormatClass(t, "format class", `
+import "fmt"
+
+var (
+	Rect
+	x int
+	y int
+)
+
+fmt.Println("hello")
+`, `var (
+	Rect
+	x int
+	y int
+)
+
+echo "hello"
 `)
 }

--- a/x/format/gopstyledir_test.go
+++ b/x/format/gopstyledir_test.go
@@ -59,7 +59,7 @@ func testFrom(t *testing.T, pkgDir, sel string) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	ret, err := GopstyleSource(src, file)
+	ret, err := XGoStyleSource(src, false, file)
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
deprecated
```
func GopstyleSource(src []byte, filename ...string) (ret []byte, err error)
func GopStyle(file *ast.File)
```
new abi
```
func XGoStyleSource(src []byte, class bool, filename ...string) (ret []byte, err error)
func XGoStyle(file *ast.File)
```