### PR TITLE
Fix typo in classfile documentation

### DIFF
--- a/doc/classfile.md
+++ b/doc/classfile.md
@@ -316,7 +316,7 @@ onMsg "4", => {
 
 We call `onStart` and `onMsg` to listen events. `onStart` is called when the program is started. And `onMsg` is called when someone calls `broadcast` to broadcast a message.
 
-When the program starts, Kai says `Where do you come from?`, and then broadcasts the message `1`. Who will recieve this message? Let's see codes in [Jaime.spx](https://github.com/goplus/spx/blob/main/tutorial/01-Weather/Jaime.spx):
+When the program starts, Kai says `Where do you come from?`, and then broadcasts the message `1`. Who will receive this message? Let's see codes in [Jaime.spx](https://github.com/goplus/spx/blob/main/tutorial/01-Weather/Jaime.spx):
 
 ```coffee
 onMsg "1", => {


### PR DESCRIPTION
Fixes a small spelling typo in the classfile tutorial text: `recieve` -> `receive`.

No code execution was needed for this docs-only change.