### PR TITLE
feat(syntax): add static value declarations

### DIFF
--- a/cl/compile_spx_test.go
+++ b/cl/compile_spx_test.go
@@ -418,9 +418,8 @@ func TestSpxRun(t *testing.T) {
 var (
 	Kai Kai
 	t   Sound
+	x   float64 = rand(1.2)
 )
-
-var x float64 = rand(1.2)
 
 run "hzip://open.qiniu.us/weather/res.zip"
 `, `
@@ -440,15 +439,19 @@ type index struct {
 	*spx.MyGame
 	Kai Kai
 	t   spx.Sound
+	x   float64
 }
 
-var x float64 = spx.Rand__1(1.2)
-
 func (this *index) MainEntry() {
+	this.XGo_Init()
 	spx.Gopt_MyGame_Run(this, "hzip://open.qiniu.us/weather/res.zip")
 }
 func (this *index) Main() {
 	spx.Gopt_MyGame_Main(this)
+}
+func (this *index) XGo_Init() *index {
+	this.x = spx.Rand__1(1.2)
+	return this
 }
 func (this *Kai) Main() {
 	fmt.Println("Hi")
@@ -887,7 +890,9 @@ func onInit() {
 }
 `, `
 var (
-	a int
+	a  int
+	m1 = &Mesh{}
+	m2 = &Mesh{}
 )
 
 type Mesh struct {
@@ -896,11 +901,6 @@ type Mesh struct {
 func (p *Mesh) Name() string {
 	return "hello"
 }
-
-var (
-	m1 = &Mesh{}
-	m2 = &Mesh{}
-)
 
 onKey "hello", => {
 }
@@ -936,7 +936,9 @@ type Game struct {
 type Kai struct {
 	spx.Sprite
 	*Game
-	a int
+	a  int
+	m1 *Mesh
+	m2 *Mesh
 }
 
 func (this *Game) onInit() {
@@ -951,11 +953,8 @@ func (this *Game) Main() {
 func (p *Mesh) Name() string {
 	return "hello"
 }
-
-var m1 = &Mesh{}
-var m2 = &Mesh{}
-
 func (this *Kai) Main() {
+	this.XGo_Init()
 	spx.Gopt_Sprite_OnKey__0(this, "hello", func() {
 	})
 	spx.Gopt_Sprite_OnKey__1(this, "hello", func(key string) {
@@ -964,19 +963,24 @@ func (this *Kai) Main() {
 	})
 	spx.Gopt_Sprite_OnKey__3(this, []string{"2"}, func(key string) {
 	})
-	spx.Gopt_Sprite_OnKey__4(this, []spx.Mesher{m1, m2}, func() {
+	spx.Gopt_Sprite_OnKey__4(this, []spx.Mesher{this.m1, this.m2}, func() {
 	})
-	spx.Gopt_Sprite_OnKey__5(this, []spx.Mesher{m1, m2}, func(key spx.Mesher) {
+	spx.Gopt_Sprite_OnKey__5(this, []spx.Mesher{this.m1, this.m2}, func(key spx.Mesher) {
 	})
 	spx.Gopt_Sprite_OnKey__6(this, []string{"a"}, []string{"b"}, func(key string) {
 	})
-	spx.Gopt_Sprite_OnKey__7(this, []string{"a"}, []spx.Mesher{m1, m2}, func(key string) {
+	spx.Gopt_Sprite_OnKey__7(this, []string{"a"}, []spx.Mesher{this.m1, this.m2}, func(key string) {
 	})
 	spx.Gopt_Sprite_OnKey__6(this, []string{"a"}, nil, func(key string) {
 	})
 	spx.Gopt_Sprite_OnKey__8(this, 100, 200)
 	spx.Gopt_Sprite_OnKey2(this, "hello", func(key string) {
 	})
+}
+func (this *Kai) XGo_Init() *Kai {
+	this.m1 = &Mesh{}
+	this.m2 = &Mesh{}
+	return this
 }
 func main() {
 	new(Game).Main()

--- a/parser/_testdata/staticvalues/Rect.gox
+++ b/parser/_testdata/staticvalues/Rect.gox
@@ -1,0 +1,8 @@
+const global = 1
+const .kind, Rect.name = "shape", "rect"
+
+var (
+	.count             int = 1
+	Rect.total, .extra int = 2, 3
+	width              int
+)

--- a/parser/_testdata/staticvalues/parser.expect
+++ b/parser/_testdata/staticvalues/parser.expect
@@ -1,0 +1,107 @@
+package main
+
+file Rect.gox
+ast.GenDecl:
+  Tok: const
+  Specs:
+    ast.ValueSpec:
+      Names:
+        ast.Ident:
+          Name: global
+      Values:
+        ast.BasicLit:
+          Kind: INT
+          Value: 1
+ast.GenDecl:
+  Tok: const
+  Specs:
+    ast.ValueSpec:
+      Names:
+        ast.Ident:
+          Name: .kind
+        ast.Ident:
+          Name: Rect.name
+      Values:
+        ast.BasicLit:
+          Kind: STRING
+          Value: "shape"
+        ast.BasicLit:
+          Kind: STRING
+          Value: "rect"
+ast.GenDecl:
+  Tok: var
+  Specs:
+    ast.ValueSpec:
+      Names:
+        ast.Ident:
+          Name: .count
+      Type:
+        ast.Ident:
+          Name: int
+      Values:
+        ast.BasicLit:
+          Kind: INT
+          Value: 1
+    ast.ValueSpec:
+      Names:
+        ast.Ident:
+          Name: Rect.total
+        ast.Ident:
+          Name: .extra
+      Type:
+        ast.Ident:
+          Name: int
+      Values:
+        ast.BasicLit:
+          Kind: INT
+          Value: 2
+        ast.BasicLit:
+          Kind: INT
+          Value: 3
+    ast.ValueSpec:
+      Names:
+        ast.Ident:
+          Name: width
+      Type:
+        ast.Ident:
+          Name: int
+
+file values.xgo
+ast.GenDecl:
+  Tok: type
+  Specs:
+    ast.TypeSpec:
+      Name:
+        ast.Ident:
+          Name: Rect
+      Type:
+        ast.Ident:
+          Name: int
+ast.GenDecl:
+  Tok: const
+  Specs:
+    ast.ValueSpec:
+      Names:
+        ast.Ident:
+          Name: Rect.kind
+        ast.Ident:
+          Name: global
+      Values:
+        ast.BasicLit:
+          Kind: STRING
+          Value: "shape"
+        ast.BasicLit:
+          Kind: STRING
+          Value: "global"
+ast.GenDecl:
+  Tok: var
+  Specs:
+    ast.ValueSpec:
+      Names:
+        ast.Ident:
+          Name: Rect.count
+        ast.Ident:
+          Name: other
+      Type:
+        ast.Ident:
+          Name: int

--- a/parser/_testdata/staticvalues/values.xgo
+++ b/parser/_testdata/staticvalues/values.xgo
@@ -1,0 +1,5 @@
+type Rect int
+
+const Rect.kind, global = "shape", "global"
+
+var Rect.count, other int

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -92,7 +92,7 @@ type parser struct {
 	syncPos token.Pos // last synchronization position
 	syncCnt int       // number of parser.advance calls without progress
 
-	varDeclCnt int // number of var decl
+	classVarDecl token.Pos // first top-level var declaration in a classfile
 
 	// Non-syntactic parser control
 	exprLev int  // < 0: in control clause, >= 0: in expression
@@ -709,15 +709,47 @@ func (p *parser) parseIdent() *ast.Ident {
 	return &ast.Ident{NamePos: pos, Name: name}
 }
 
-func (p *parser) parseIdentList() (list []*ast.Ident) {
-	if p.trace {
-		defer un(trace(p, "IdentList"))
+func (p *parser) parseValueName(allowDot bool) (*ast.Ident, bool) {
+	if allowDot && p.tok == token.PERIOD {
+		dot := p.pos
+		p.next()
+		name := p.parseIdent()
+		p.checkStaticValueNameSpacing(token.NoPos, dot, name.Pos())
+		name.NamePos = dot
+		name.Name = "." + name.Name
+		return name, true
 	}
+	name := p.parseIdent()
+	if p.tok != token.PERIOD {
+		return name, false
+	}
+	dot := p.pos
+	p.next()
+	sel := p.parseIdent()
+	p.checkStaticValueNameSpacing(name.End(), dot, sel.Pos())
+	name.Name += "." + sel.Name
+	return name, true
+}
 
-	list = append(list, p.parseIdent())
+func (p *parser) checkStaticValueNameSpacing(leftEnd, dot, right token.Pos) {
+	const msg = "whitespace is not allowed in static value name"
+	if leftEnd.IsValid() && leftEnd != dot {
+		p.error(dot, msg)
+	}
+	if right != dot+1 {
+		p.error(right, msg)
+	}
+}
+
+func (p *parser) parseValueNameList(allowDot bool) (list []*ast.Ident, hasStatic bool) {
+	name, static := p.parseValueName(allowDot)
+	list = append(list, name)
+	hasStatic = static
 	for p.tok == token.COMMA {
 		p.next()
-		list = append(list, p.parseIdent())
+		name, static = p.parseValueName(allowDot)
+		list = append(list, name)
+		hasStatic = hasStatic || static
 	}
 	return
 }
@@ -3950,45 +3982,58 @@ func (p *parser) inClassFile() bool {
 	return p.mode&ParseXGoClass != 0
 }
 
-func (p *parser) parseValueSpec(doc *ast.CommentGroup, keyword token.Token, iota int) ast.Spec {
-	if p.trace {
-		defer un(trace(p, keyword.String()+"Spec"))
+func (p *parser) parseClassValueSpec() (idents []*ast.Ident, typ ast.Expr, tag *ast.BasicLit, values []ast.Expr, hasStatic bool) {
+	var starPos token.Pos
+	if p.tok == token.MUL {
+		starPos = p.pos
+		p.next()
 	}
-
-	pos := p.pos
-	var idents []*ast.Ident
-	var typ ast.Expr
-	var tag *ast.BasicLit
-	var values []ast.Expr
-	if p.inClassFile() && p.topScope == p.pkgScope && keyword == token.VAR && p.varDeclCnt == 1 {
-		var starPos token.Pos
-		if p.tok == token.MUL {
-			starPos = p.pos
+	if p.tok == token.PERIOD && starPos == token.NoPos {
+		idents, hasStatic = p.parseValueNameList(true)
+		typ = p.tryType()
+		if p.tok == token.ASSIGN {
 			p.next()
+			values = p.parseRHSList()
 		}
+	} else {
 		ident := p.parseIdent()
 		if p.tok == token.PERIOD {
+			dot := p.pos
 			p.next()
-			typ = &ast.SelectorExpr{
-				X:   ident,
-				Sel: p.parseIdent(),
-			}
-			if starPos != token.NoPos {
-				typ = &ast.StarExpr{
-					Star: starPos,
-					X:    typ,
+			selOK := p.tok == token.IDENT
+			sel := p.parseIdent()
+			if selOK && starPos == token.NoPos &&
+				p.tok != token.SEMICOLON && p.tok != token.STRING && p.tok != token.RPAREN {
+				p.checkStaticValueNameSpacing(ident.End(), dot, sel.Pos())
+				ident.Name += "." + sel.Name
+				idents = append(idents, ident)
+				hasStatic = true
+				for p.tok == token.COMMA {
+					p.next()
+					name, static := p.parseValueName(true)
+					idents = append(idents, name)
+					hasStatic = hasStatic || static
+				}
+				typ = p.tryType()
+				if p.tok == token.ASSIGN {
+					p.next()
+					values = p.parseRHSList()
+				}
+			} else {
+				typ = &ast.SelectorExpr{X: ident, Sel: sel}
+				if starPos != token.NoPos {
+					typ = &ast.StarExpr{Star: starPos, X: typ}
 				}
 			}
 		} else if starPos != token.NoPos {
-			typ = &ast.StarExpr{
-				Star: starPos,
-				X:    ident,
-			}
+			typ = &ast.StarExpr{Star: starPos, X: ident}
 		} else {
 			idents = append(idents, ident)
 			for p.tok == token.COMMA {
 				p.next()
-				idents = append(idents, p.parseIdent())
+				name, static := p.parseValueName(true)
+				idents = append(idents, name)
+				hasStatic = hasStatic || static
 			}
 			typ = p.tryType()
 			if p.tok == token.ASSIGN {
@@ -3999,13 +4044,30 @@ func (p *parser) parseValueSpec(doc *ast.CommentGroup, keyword token.Token, iota
 				idents = nil
 			}
 		}
-		if p.tok == token.STRING {
-			tag = &ast.BasicLit{ValuePos: p.pos, Kind: p.tok, Value: p.lit}
-			p.next()
-		}
-		p.expect(token.SEMICOLON)
+	}
+	if p.tok == token.STRING {
+		tag = &ast.BasicLit{ValuePos: p.pos, Kind: p.tok, Value: p.lit}
+		p.next()
+	}
+	p.expect(token.SEMICOLON)
+	return
+}
+
+func (p *parser) parseValueSpec(doc *ast.CommentGroup, keyword token.Token, iota int) ast.Spec {
+	if p.trace {
+		defer un(trace(p, keyword.String()+"Spec"))
+	}
+
+	pos := p.pos
+	var idents []*ast.Ident
+	var typ ast.Expr
+	var tag *ast.BasicLit
+	var values []ast.Expr
+	var hasStatic bool
+	if p.inClassFile() && p.topScope == p.pkgScope && keyword == token.VAR {
+		idents, typ, tag, values, hasStatic = p.parseClassValueSpec()
 	} else {
-		idents = p.parseIdentList()
+		idents, hasStatic = p.parseValueNameList(p.inClassFile())
 		typ = p.tryType()
 		// always permit optional initialization for more tolerant parsing
 		if p.tok == token.ASSIGN {
@@ -4030,12 +4092,13 @@ func (p *parser) parseValueSpec(doc *ast.CommentGroup, keyword token.Token, iota
 	// the end of the innermost containing block.
 	// (Global identifiers are resolved in a separate phase after parsing.)
 	spec := &ast.ValueSpec{
-		Doc:     doc,
-		Names:   idents,
-		Type:    typ,
-		Tag:     tag,
-		Values:  values,
-		Comment: p.lineComment,
+		Doc:       doc,
+		Names:     idents,
+		Type:      typ,
+		Tag:       tag,
+		Values:    values,
+		Comment:   p.lineComment,
+		HasStatic: hasStatic,
 	}
 	kind := ast.Con
 	if keyword == token.VAR {
@@ -4109,11 +4172,15 @@ func (p *parser) parseGenDecl(keyword token.Token, f parseSpecFunction) *ast.Gen
 	if p.trace {
 		defer un(trace(p, "GenDecl("+keyword.String()+")"))
 	}
-	if keyword == token.VAR {
-		p.varDeclCnt++
-	}
 	doc := p.leadComment
 	pos := p.expect(keyword)
+	if keyword == token.VAR && p.inClassFile() && p.topScope == p.pkgScope {
+		if p.classVarDecl.IsValid() {
+			p.error(pos, "multiple top-level var declarations in classfile")
+		} else {
+			p.classVarDecl = pos
+		}
+	}
 	var lparen, rparen token.Pos
 	var list []ast.Spec
 	if p.tok == token.LPAREN {

--- a/parser/parser_test.go
+++ b/parser/parser_test.go
@@ -18,6 +18,7 @@ package parser
 
 import (
 	"io/fs"
+	"strings"
 	"testing"
 
 	"github.com/goplus/xgo/ast"
@@ -62,6 +63,94 @@ func TestAssert(t *testing.T) {
 		}
 	}()
 	assert(false, "panic msg")
+}
+
+func TestStaticValueSpecs(t *testing.T) {
+	fset := token.NewFileSet()
+	f, err := ParseEntry(fset, "/foo/Rect.gox", `const global = 1
+const .kind, Rect.name = "shape", "rect"
+var (
+	.count int = 1
+	Rect.total, .extra int = 2, 3
+	width int
+)
+`, Config{Mode: ParseXGoClass | AllErrors})
+	if err != nil {
+		t.Fatal("ParseEntry:", err)
+	}
+	for i, want := range []struct {
+		names     []string
+		hasStatic bool
+	}{
+		{[]string{"global"}, false},
+		{[]string{".kind", "Rect.name"}, true},
+		{[]string{".count"}, true},
+		{[]string{"Rect.total", ".extra"}, true},
+		{[]string{"width"}, false},
+	} {
+		decl := f.Decls[2]
+		specIndex := i - 2
+		if i < 2 {
+			decl = f.Decls[i]
+			specIndex = 0
+		}
+		spec := decl.(*ast.GenDecl).Specs[specIndex].(*ast.ValueSpec)
+		if spec.HasStatic != want.hasStatic || len(spec.Names) != len(want.names) {
+			t.Fatalf("spec %d = %#v", i, spec)
+		}
+		for j, name := range want.names {
+			if spec.Names[j].Name != name {
+				t.Fatalf("spec %d name %d = %q, want %q", i, j, spec.Names[j].Name, name)
+			}
+		}
+	}
+	if got := f.ClassFieldsDecl(); got != f.Decls[2] {
+		t.Fatalf("ClassFieldsDecl = %p, want %p", got, f.Decls[2])
+	}
+}
+
+func TestStaticValueSpecWhitespaceErrors(t *testing.T) {
+	for _, test := range []struct {
+		name string
+		code string
+	}{
+		{"before dot", "var (\nRect .count int\n)\n"},
+		{"after shorthand dot", "var (\n. count int\n)\n"},
+		{"after receiver dot", "var (\nRect. count int\n)\n"},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			fset := token.NewFileSet()
+			_, err := ParseEntry(fset, "/foo/Rect.gox", test.code, Config{
+				Mode: ParseXGoClass | AllErrors,
+			})
+			if err == nil || !strings.Contains(err.Error(), "whitespace is not allowed in static value name") {
+				t.Fatalf("ParseEntry error = %v", err)
+			}
+		})
+	}
+	t.Run("qualified embedded type", func(t *testing.T) {
+		fset := token.NewFileSet()
+		_, err := ParseEntry(fset, "/foo/Rect.gox", "var (\npkg . Type\n)\n", Config{
+			Mode: ParseXGoClass | AllErrors,
+		})
+		if err != nil {
+			t.Fatalf("ParseEntry error = %v", err)
+		}
+	})
+}
+
+func TestClassfileMultipleVarDecls(t *testing.T) {
+	fset := token.NewFileSet()
+	_, err := ParseEntry(fset, "/foo/Rect.gox", `var (
+	width int
+)
+var (
+	Rect.count int
+)
+`, Config{Mode: ParseXGoClass | AllErrors})
+	if err == nil || !strings.Contains(err.Error(), "multiple top-level var declarations in classfile") {
+		t.Fatalf("ParseEntry error = %v", err)
+	}
 }
 
 func panicMsg(e any) string {


### PR DESCRIPTION
## Summary
- Adds syntax-only support for static value declarations such as `const T.name = ...`, `var T.count int`, and classfile `.name` shorthand.
- Requires static value names to be contiguous: `T.name` and `.name` are valid, while `T .name`, `T. name`, and `. name` are parse-time errors.
- Restricts classfiles to one top-level `var` declaration, containing static and bare variables in the same block.
- Part of #2513.

## Implementation
- Uses `ValueSpec.HasStatic` from #2785 and encodes static forms in `Names` as `T.name` or `.name`.
- Detects whitespace around static-name dots from token positions.
- Reports a parse-time error for a second top-level classfile `var` declaration.
- Contains no `cl` or `gogen` semantic implementation; the `cl` test update only aligns existing fixtures with the revised grammar.

## Testing
- `go test -coverprofile=coverage.txt -covermode=atomic ./...` passes.
- Parser coverage: 95.0% → 95.2%.
- Printer coverage remains 89.4%.