### PR TITLE
feat(spx): support Warp func declarations

### DIFF
--- a/ast/ast_xgo.go
+++ b/ast/ast_xgo.go
@@ -95,6 +95,7 @@ func (*EnumType) exprNode() {}
 // A FuncDecl node represents a function declaration.
 type FuncDecl struct {
 	Doc      *CommentGroup // associated documentation; or nil
+	Wrap     *Ident        // wrapper modifier before "func"; or nil
 	Recv     *FieldList    // receiver (methods); or nil (functions)
 	Name     *Ident        // function/method name
 	Type     *FuncType     // function signature: parameters, results, and position of "func" keyword
@@ -106,7 +107,12 @@ type FuncDecl struct {
 }
 
 // Pos returns position of first character belonging to the node.
-func (d *FuncDecl) Pos() token.Pos { return d.Type.Pos() }
+func (d *FuncDecl) Pos() token.Pos {
+	if d.Wrap != nil {
+		return d.Wrap.Pos()
+	}
+	return d.Type.Pos()
+}
 
 // End returns position of first character immediately after the node.
 func (d *FuncDecl) End() token.Pos {

--- a/ast/walk.go
+++ b/ast/walk.go
@@ -367,6 +367,9 @@ func Walk(v Visitor, node Node) {
 			if n.Doc != nil {
 				Walk(v, n.Doc)
 			}
+			if n.Wrap != nil {
+				Walk(v, n.Wrap)
+			}
 			if n.Recv != nil {
 				Walk(v, n.Recv)
 			}

--- a/cl/classfile.go
+++ b/cl/classfile.go
@@ -36,6 +36,11 @@ import (
 
 // -----------------------------------------------------------------------------
 
+const (
+	classConstSched    = "Gop_sched"
+	classConstWrapCall = "Gop_wrapCall"
+)
+
 type classFile struct {
 	name    string // class type, empty for default project class
 	clsfile string
@@ -72,19 +77,20 @@ func workClassByProto(works []*workClass, proto string) *workClass {
 }
 
 type classProject struct {
-	gameClass_ string       // project class type name
-	game       gogen.Ref    // Game (project base class)
-	works      []*workClass // work classes grouped by extension
-	scheds     []string
-	schedStmts []target.Stmt // nil or len(scheds) == 2 (delayload)
-	pkgImps    []gogen.PkgRef
-	pkgPaths   []string
-	autoimps   map[string]pkgImp // auto-import statement in gox.mod
-	gt         *Project
-	hasScheds  bool
-	gameIsPtr  bool
-	isTest     bool
-	hasMain_   bool
+	gameClass_   string       // project class type name
+	game         gogen.Ref    // Game (project base class)
+	works        []*workClass // work classes grouped by extension
+	scheds       []string
+	wrapFuncCall string        // wrapper callable for wrapped function declarations
+	schedStmts   []target.Stmt // nil or len(scheds) == 2 (delayload)
+	pkgImps      []gogen.PkgRef
+	pkgPaths     []string
+	autoimps     map[string]pkgImp // auto-import statement in gox.mod
+	gt           *Project
+	hasScheds    bool
+	gameIsPtr    bool
+	isTest       bool
+	hasMain_     bool
 }
 
 func (p *classProject) embed(chk func(name string) bool, flds []*types.Var, pkg *gogen.Package) []*types.Var {
@@ -305,8 +311,11 @@ func loadClass(ctx *pkgCtx, pkg *gogen.Package, file string, f *ast.File, conf *
 			p.game, p.gameIsPtr = classPkgRef(classPkg, gt.Class)
 			workClassFeatures(p.game, works)
 		}
-		if x := getStringConst(classPkg, "Gop_sched"); x != "" { // keep Gop_sched
+		if x := getStringConst(classPkg, classConstSched); x != "" { // keep Gop_sched
 			p.scheds, p.hasScheds = strings.SplitN(x, ",", 2), true
+		}
+		if x := getStringConst(classPkg, classConstWrapCall); x != "" {
+			p.wrapFuncCall = x
 		}
 	}
 	cls := &classFile{clsfile: clsfile, ext: ext, proj: p}

--- a/cl/compile.go
+++ b/cl/compile.go
@@ -1490,7 +1490,12 @@ func loadFunc(ctx *blockCtx, recv *types.Var, name string, d *ast.FuncDecl, genB
 		}
 	}
 	if genBody {
-		if body := d.Body; body != nil {
+		body, err := wrapFuncBody(ctx, d)
+		if err != nil {
+			ctx.handleErr(err)
+			return
+		}
+		if body != nil {
 			if recv != nil {
 				file := pkg.CurFile()
 				ctx.inits = append(ctx.inits, func() { // interface issue: #795

--- a/cl/compile_spx_test.go
+++ b/cl/compile_spx_test.go
@@ -299,6 +299,178 @@ func main() {
 `)
 }
 
+func TestSpxWarpFuncDecl(t *testing.T) {
+	gopSpxTest(t, `
+Warp func setScore(score int, label string) {
+	TestIntValue = score
+}
+
+setScore 7, "ok"
+`, ``, `package main
+
+import "github.com/goplus/xgo/cl/internal/spx"
+
+type bar struct {
+	spx.Sprite
+	*index
+}
+type index struct {
+	*spx.MyGame
+}
+
+func (this *index) setScore(score int, label string) {
+	spx.Warp(func() {
+		spx.TestIntValue = score
+	})
+}
+func (this *index) MainEntry() {
+	this.setScore(7, "ok")
+}
+func (this *index) Main() {
+	spx.Gopt_MyGame_Main(this)
+}
+func (this *bar) Main() {
+}
+func main() {
+	new(index).Main()
+}
+`)
+}
+
+func TestSpxWarpFuncLiteralCall(t *testing.T) {
+	gopSpxTest(t, `
+Warp func() {
+	TestIntValue = 7
+}
+`, ``, `package main
+
+import "github.com/goplus/xgo/cl/internal/spx"
+
+type bar struct {
+	spx.Sprite
+	*index
+}
+type index struct {
+	*spx.MyGame
+}
+
+func (this *index) MainEntry() {
+	spx.Warp(func() {
+		spx.TestIntValue = 7
+	})
+}
+func (this *index) Main() {
+	spx.Gopt_MyGame_Main(this)
+}
+func (this *bar) Main() {
+}
+func main() {
+	new(index).Main()
+}
+`)
+}
+
+func TestSpxWarpFuncShadow(t *testing.T) {
+	gopSpxTest(t, `
+func Warp(fn func()) {
+	fn()
+}
+
+Warp func target(n int) int {
+	return n + 1
+}
+
+x := target(7)
+println x
+`, ``, `package main
+
+import (
+	"fmt"
+	"github.com/goplus/xgo/cl/internal/spx"
+)
+
+type bar struct {
+	spx.Sprite
+	*index
+}
+type index struct {
+	*spx.MyGame
+}
+
+func (this *index) Warp(fn func()) {
+	fn()
+}
+func (this *index) target(n int) int {
+	var __gop_wrap_ret0 int
+	this.Warp(func() {
+		__gop_wrap_ret0 = func() int {
+			return n + 1
+		}()
+	})
+	return __gop_wrap_ret0
+}
+func (this *index) MainEntry() {
+	x := this.target(7)
+	fmt.Println(x)
+}
+func (this *index) Main() {
+	spx.Gopt_MyGame_Main(this)
+}
+func (this *bar) Main() {
+}
+func main() {
+	new(index).Main()
+}
+`)
+}
+
+func TestSpxWarpFuncReturnTempNameCollision(t *testing.T) {
+	gopSpxTest(t, `
+Warp func target(__gop_wrap_ret0 int) int {
+	return __gop_wrap_ret0 + 1
+}
+
+x := target(7)
+println x
+`, ``, `package main
+
+import (
+	"fmt"
+	"github.com/goplus/xgo/cl/internal/spx"
+)
+
+type bar struct {
+	spx.Sprite
+	*index
+}
+type index struct {
+	*spx.MyGame
+}
+
+func (this *index) target(__gop_wrap_ret0 int) int {
+	var __gop_wrap_ret1 int
+	spx.Warp(func() {
+		__gop_wrap_ret1 = func() int {
+			return __gop_wrap_ret0 + 1
+		}()
+	})
+	return __gop_wrap_ret1
+}
+func (this *index) MainEntry() {
+	x := this.target(7)
+	fmt.Println(x)
+}
+func (this *index) Main() {
+	spx.Gopt_MyGame_Main(this)
+}
+func (this *bar) Main() {
+}
+func main() {
+	new(index).Main()
+}
+`)
+}
+
 func TestSpxMethod(t *testing.T) {
 	gopSpxTestEx(t, `
 func onInit() {

--- a/cl/internal/spx/game.go
+++ b/cl/internal/spx/game.go
@@ -17,8 +17,9 @@
 package spx
 
 const (
-	GopPackage = "github.com/goplus/xgo/cl/internal/spx/pkg"
-	Gop_sched  = "Sched,SchedNow"
+	GopPackage   = "github.com/goplus/xgo/cl/internal/spx/pkg"
+	Gop_sched    = "Sched,SchedNow"
+	Gop_wrapCall = "Warp"
 )
 
 type Sound string
@@ -72,6 +73,10 @@ func Sched() {
 }
 
 func SchedNow() {
+}
+
+func Warp(fn func()) {
+	fn()
 }
 
 func Rand__0(int) int {

--- a/cl/internal/spx4/game.go
+++ b/cl/internal/spx4/game.go
@@ -17,8 +17,9 @@
 package spx4
 
 const (
-	GopPackage = "github.com/goplus/xgo/cl/internal/spx/pkg"
-	Gop_sched  = "Sched,SchedNow"
+	GopPackage   = "github.com/goplus/xgo/cl/internal/spx/pkg"
+	Gop_sched    = "Sched,SchedNow"
+	Gop_wrapCall = "Warp"
 )
 
 type Sound string
@@ -76,6 +77,10 @@ func Sched() {
 }
 
 func SchedNow() {
+}
+
+func Warp(fn func()) {
+	fn()
 }
 
 func Rand__0(int) int {

--- a/cl/outline/outline.go
+++ b/cl/outline/outline.go
@@ -257,10 +257,8 @@ func (p Package) Outline(withUnexported ...bool) (ret *All) {
 				named.Helpers = append(named.Helpers, Func{v, p.docs})
 			}
 		case *types.Const:
-			if name := v.Name(); strings.HasPrefix(name, "Gop") || strings.HasPrefix(name, "XGo") {
-				if name == "GopPackage" || name == "XGoPackage" || name == "Gop_sched" {
-					continue
-				}
+			if isCompilerMetadataConst(v.Name()) {
+				continue
 			}
 			typ := v.Type()
 			if !all {
@@ -279,6 +277,17 @@ func (p Package) Outline(withUnexported ...bool) (ret *All) {
 		}
 	}
 	return
+}
+
+func isCompilerMetadataConst(name string) bool {
+	if !strings.HasPrefix(name, "Gop") && !strings.HasPrefix(name, "XGo") {
+		return false
+	}
+	switch name {
+	case "GopPackage", "XGoPackage", "Gop_sched", "Gop_wrapCall":
+		return true
+	}
+	return false
 }
 
 // -----------------------------------------------------------------------------

--- a/cl/wrap_func.go
+++ b/cl/wrap_func.go
@@ -1,0 +1,205 @@
+/*
+ * Copyright (c) 2026 The XGo Authors (xgo.dev). All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package cl
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/goplus/xgo/ast"
+	"github.com/goplus/xgo/token"
+)
+
+const wrapFuncResultPrefix = "__gop_wrap_ret"
+
+func wrapFuncBody(ctx *blockCtx, decl *ast.FuncDecl) (*ast.BlockStmt, error) {
+	body := decl.Body
+	modifier := decl.Wrap
+	if modifier == nil || body == nil {
+		return body, nil
+	}
+
+	wrapCall, err := wrapFuncCallName(ctx, modifier)
+	if err != nil {
+		return nil, err
+	}
+	if resultCount(decl.Type.Results) == 0 {
+		return wrapFuncBodyNoResults(modifier, wrapCall, body), nil
+	}
+	return wrapFuncBodyWithResults(decl, modifier, wrapCall, body), nil
+}
+
+func wrapFuncCallName(ctx *blockCtx, modifier *ast.Ident) (string, error) {
+	if ctx == nil || ctx.proj == nil {
+		return "", fmt.Errorf("%s func is only supported in classfiles with %s", modifier.Name, classConstWrapCall)
+	}
+
+	wrapCall := ctx.proj.wrapFuncCall
+	if wrapCall == "" {
+		return "", ctx.newCodeErrorf(
+			modifier.Pos(), modifier.End(), "%s func requires class package const %s", modifier.Name, classConstWrapCall,
+		)
+	}
+	if !strings.EqualFold(modifier.Name, wrapCall) {
+		return "", ctx.newCodeErrorf(
+			modifier.Pos(), modifier.End(), "%s func doesn't match class package %s = %q", modifier.Name, classConstWrapCall, wrapCall,
+		)
+	}
+	return wrapCall, nil
+}
+
+func wrapFuncBodyNoResults(modifier *ast.Ident, wrapCall string, body *ast.BlockStmt) *ast.BlockStmt {
+	call := wrapFuncCallStmt(modifier, wrapCall, wrapFuncClosure(modifier.Pos(), body))
+	return wrapFuncBlock(body, []ast.Stmt{call})
+}
+
+func wrapFuncBodyWithResults(decl *ast.FuncDecl, modifier *ast.Ident, wrapCall string, body *ast.BlockStmt) *ast.BlockStmt {
+	decls, lhs, ret := wrapFuncResultVars(decl.Type.Results, wrapFuncSignatureNames(decl))
+	assign := &ast.AssignStmt{
+		Lhs: lhs,
+		Tok: token.ASSIGN,
+		Rhs: []ast.Expr{&ast.CallExpr{
+			Fun: &ast.FuncLit{
+				Type: &ast.FuncType{
+					Func:    decl.Type.Func,
+					Params:  &ast.FieldList{},
+					Results: decl.Type.Results,
+				},
+				Body: body,
+			},
+		}},
+	}
+	call := wrapFuncCallStmt(modifier, wrapCall, &ast.FuncLit{
+		Type: wrapFuncClosureType(modifier.Pos()),
+		Body: &ast.BlockStmt{
+			List: []ast.Stmt{assign},
+		},
+	})
+
+	stmts := make([]ast.Stmt, 0, len(decls)+2)
+	for _, spec := range decls {
+		stmts = append(stmts, &ast.DeclStmt{Decl: &ast.GenDecl{
+			Tok:   token.VAR,
+			Specs: []ast.Spec{spec},
+		}})
+	}
+	stmts = append(stmts, call, &ast.ReturnStmt{Results: ret})
+	return wrapFuncBlock(body, stmts)
+}
+
+func wrapFuncCallStmt(modifier *ast.Ident, wrapCall string, closure *ast.FuncLit) *ast.ExprStmt {
+	return &ast.ExprStmt{X: &ast.CallExpr{
+		Fun:  cloneIdentWithName(modifier, wrapCall),
+		Args: []ast.Expr{closure},
+	}}
+}
+
+func wrapFuncBlock(src *ast.BlockStmt, list []ast.Stmt) *ast.BlockStmt {
+	return &ast.BlockStmt{
+		Lbrace: src.Lbrace,
+		List:   list,
+		Rbrace: src.Rbrace,
+	}
+}
+
+func wrapFuncClosure(pos token.Pos, body *ast.BlockStmt) *ast.FuncLit {
+	return &ast.FuncLit{
+		Type: wrapFuncClosureType(pos),
+		Body: body,
+	}
+}
+
+func wrapFuncClosureType(pos token.Pos) *ast.FuncType {
+	return &ast.FuncType{
+		Func:   pos,
+		Params: &ast.FieldList{},
+	}
+}
+
+func wrapFuncResultVars(results *ast.FieldList, used map[string]bool) (decls []*ast.ValueSpec, lhs []ast.Expr, ret []ast.Expr) {
+	for _, field := range results.List {
+		count := len(field.Names)
+		if count == 0 {
+			count = 1
+		}
+		spec := &ast.ValueSpec{Type: field.Type}
+		for i := 0; i < count; i++ {
+			name := wrapFuncResultName(used)
+			spec.Names = append(spec.Names, ast.NewIdent(name))
+			lhs = append(lhs, ast.NewIdent(name))
+			ret = append(ret, ast.NewIdent(name))
+		}
+		decls = append(decls, spec)
+	}
+	return
+}
+
+func wrapFuncResultName(used map[string]bool) string {
+	for i := 0; ; i++ {
+		name := fmt.Sprintf("%s%d", wrapFuncResultPrefix, i)
+		if !used[name] {
+			used[name] = true
+			return name
+		}
+	}
+}
+
+func wrapFuncSignatureNames(decl *ast.FuncDecl) map[string]bool {
+	used := make(map[string]bool)
+	collectWrapFuncNames(used, decl.Recv)
+	collectWrapFuncNames(used, decl.Type.Params)
+	collectWrapFuncNames(used, decl.Type.Results)
+	return used
+}
+
+func collectWrapFuncNames(used map[string]bool, fields *ast.FieldList) {
+	if fields == nil {
+		return
+	}
+	for _, field := range fields.List {
+		for _, name := range field.Names {
+			if name.Name != "_" {
+				used[name.Name] = true
+			}
+		}
+	}
+}
+
+func resultCount(results *ast.FieldList) int {
+	if results == nil {
+		return 0
+	}
+	count := 0
+	for _, field := range results.List {
+		if len(field.Names) == 0 {
+			count++
+			continue
+		}
+		count += len(field.Names)
+	}
+	return count
+}
+
+func cloneIdentWithName(v *ast.Ident, name string) *ast.Ident {
+	if v == nil {
+		return nil
+	}
+	if name == "" {
+		name = v.Name
+	}
+	return &ast.Ident{NamePos: v.NamePos, Name: name}
+}

--- a/cl/wrap_func_test.go
+++ b/cl/wrap_func_test.go
@@ -1,0 +1,30 @@
+//go:build !genjs
+
+/*
+ * Copyright (c) 2026 The XGo Authors (xgo.dev). All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package cl_test
+
+import "testing"
+
+func TestWrapFuncDeclRequiresWrapCallConst(t *testing.T) {
+	gopSpxErrorTestMap(t,
+		`demo.gsh:1:1: Warp func requires class package const Gop_wrapCall`,
+		map[string][]string{"/foo": {"demo.gsh"}},
+		map[string]string{"/foo/demo.gsh": `Warp func foo() {
+}`},
+	)
+}

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -4364,6 +4364,65 @@ func (p *parser) parseFuncDeclOrCall() (ast.Decl, *ast.CallExpr) {
 	return decl, nil
 }
 
+const wrapFuncModifier = "Warp"
+
+func isWrapFuncModifier(name string) bool {
+	return strings.EqualFold(name, wrapFuncModifier)
+}
+
+func (p *parser) isWrapFuncDecl() bool {
+	leadComment, lineComment := p.leadComment, p.lineComment
+	pos, tok, lit := p.pos, p.tok, p.lit // current token must be func
+	// Keep `Warp func() {}` as a normal command call, but recognize `Warp func Foo`.
+	p.next()
+	ok := p.tok == token.IDENT
+	p.unget(pos, tok, lit)
+	p.leadComment, p.lineComment = leadComment, lineComment
+	return ok
+}
+
+func (p *parser) parseWrapFuncDecl(sync map[token.Token]bool) (ast.Decl, bool) {
+	if !p.inClassFile() || !isWrapFuncModifier(p.lit) {
+		return nil, false
+	}
+
+	wrap := &ast.Ident{NamePos: p.pos, Name: p.lit}
+	doc := p.leadComment
+	p.next()
+	if p.tok != token.FUNC {
+		p.unget(wrap.Pos(), token.IDENT, wrap.Name)
+		return nil, false
+	}
+
+	if !p.isWrapFuncDecl() {
+		p.resolve(wrap)
+		call := p.parseCallOrConversion(wrap, true)
+		p.expectSemi()
+		return p.parseGlobalStmts(sync, wrap.Pos(), &ast.ExprStmt{X: call}), true
+	}
+
+	decl, _ := p.parseFuncDeclOrCall()
+	if fn, ok := decl.(*ast.FuncDecl); ok {
+		fn.Wrap = wrap
+		if fn.Doc == nil {
+			fn.Doc = doc
+		}
+		if p.errors.Len() != 0 {
+			p.advance(sync)
+		}
+		return fn, true
+	}
+
+	p.error(wrap.Pos(), "warp modifier requires a named function declaration")
+	if p.errors.Len() != 0 {
+		p.advance(sync)
+	}
+	if decl != nil {
+		return decl, true
+	}
+	return &ast.BadDecl{From: wrap.Pos(), To: p.pos}, true
+}
+
 func (p *parser) parseDecl(sync map[token.Token]bool) ast.Decl {
 	if p.trace {
 		defer un(trace(p, "Declaration"))
@@ -4384,6 +4443,11 @@ func (p *parser) parseDecl(sync map[token.Token]bool) ast.Decl {
 			return decl
 		}
 		return p.parseGlobalStmts(sync, pos, &ast.ExprStmt{X: call})
+	case token.IDENT:
+		if decl, ok := p.parseWrapFuncDecl(sync); ok {
+			return decl
+		}
+		return p.parseGlobalStmts(sync, pos)
 	default:
 		return p.parseGlobalStmts(sync, pos)
 	}

--- a/printer/nodes.go
+++ b/printer/nodes.go
@@ -2112,7 +2112,11 @@ func (p *printer) funcDecl(d *ast.FuncDecl) {
 		return
 	}
 
-	pos := d.Pos()
+	if d.Wrap != nil {
+		p.expr(d.Wrap)
+		p.print(blank)
+	}
+	pos := d.Type.Pos()
 	p.print(pos, token.FUNC, blank)
 	// We have to save startCol only after emitting FUNC; otherwise it can be on a
 	// different line (all whitespace preceding the FUNC is emitted only when the
@@ -2136,7 +2140,7 @@ func (p *printer) funcDecl(d *ast.FuncDecl) {
 		p.print(blank)
 	}
 	p.signature(d.Type.Params, d.Type.Results)
-	p.funcBody(p.distanceFrom(d.Pos(), startCol), vtab, d.Body)
+	p.funcBody(p.distanceFrom(pos, startCol), vtab, d.Body)
 }
 
 func (p *printer) overloadFuncDecl(d *ast.OverloadFuncDecl) {

--- a/printer/xgo_test.go
+++ b/printer/xgo_test.go
@@ -89,6 +89,30 @@ func bar() {
 	}
 }
 
+func TestWrappedFuncDecl(t *testing.T) {
+	var dst bytes.Buffer
+	fset := token.NewFileSet()
+	if err := format.Node(&dst, fset, &ast.File{
+		Name: &ast.Ident{Name: "main"},
+		Decls: []ast.Decl{
+			&ast.FuncDecl{
+				Wrap: &ast.Ident{Name: "Warp"},
+				Type: &ast.FuncType{Params: &ast.FieldList{}},
+				Name: &ast.Ident{Name: "fast"},
+				Body: &ast.BlockStmt{},
+			},
+		},
+		NoPkgDecl: true,
+	}); err != nil {
+		t.Fatal("format.Node failed:", err)
+	}
+	if dst.String() != `Warp func fast() {
+}
+` {
+		t.Fatal("TestWrappedFuncDecl:", dst.String())
+	}
+}
+
 func diffBytes(t *testing.T, dst, src []byte) {
 	line := 1
 	offs := 0 // line offset


### PR DESCRIPTION
## Summary
- Add classfile support for `Warp func Foo(...) { ... }` declarations.
- Read `Gop_wrapCall` metadata from class packages and lower wrapped function bodies to `Warp(func(){ ... })`.
- Preserve return signatures by capturing wrapped-body results in generated temporaries.
- Keep `Warp func() { ... }` as an ordinary explicit closure call.
- Add AST/printer support and SPX compiler regression tests.

## Related
Updates https://github.com/goplus/xgo/issues/2756

## Tests
- `go test ./parser ./printer ./cl`