### PR TITLE
fix: handle XGo AST extension nodes consistently

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -13,12 +13,13 @@ When implementing new language syntax, follow this three-phase approach:
 - Allows grammar to be reviewed independently from implementation details
 
 #### Phase 1: Grammar Definition (First Pull Request)
-**Scope**: AST, parser, and printer modifications ONLY
+**Scope**: AST, parser, printer, and required AST consumer modifications ONLY
 - **AST**: Define new node types in `ast/` directory (if needed - often existing nodes can be reused)
 - **Parser**: Implement parsing rules in `parser/` directory to recognize the new syntax
 - **Printer**: Add formatting support for new syntax (inverse of parsing) in `printer/` directory
-- **Testing**: Add test cases in `parser/_testdata/` for new syntax
-  - **Note**: Printer shares test cases with parser - do NOT create separate test files in `printer/_testdata/`
+- **AST Consumers**: Audit manually maintained consumers such as `ast.Walk`, `ast/filter.go`, parser expression validation, and `x/format`
+- **Testing**: Add test cases in `parser/_testdata/` for new syntax and focused unit tests for affected AST consumers
+  - **Note**: Printer reuses parser test cases and also has printer-specific cases in `printer/_testdata/`
 - **What NOT to include**: Do NOT add any code generation or semantic logic in `cl/` package - that belongs in Phase 2
 
 #### Phase 2: Semantic Implementation (Second Pull Request)
@@ -71,7 +72,7 @@ When submitting a new PR to the `gogen` repository for a change, also submit a P
 
 ### Testing Requirements
 
-- **Phase 1**: 100% test coverage for new syntax parsing in `parser/_testdata/`
+- **Phase 1**: 100% test coverage for new syntax parsing in `parser/_testdata/` and focused tests for affected AST consumers
 - **Phase 2**: Comprehensive test coverage for semantic implementation in `cl/_testxgo/` covering:
   - Common usage scenarios
   - Edge cases and error conditions

--- a/ast/filter.go
+++ b/ast/filter.go
@@ -194,6 +194,9 @@ func filterType(typ Expr, f Filter, export bool) bool {
 			// Note: TupleType doesn't have an Incomplete field like StructType
 		}
 		return t.Fields != nil && len(t.Fields.List) > 0
+	case *EnumType:
+		t.Specs = filterSpecList(t.Specs, f, export)
+		return len(t.Specs) > 0
 	}
 	return false
 }

--- a/ast/filter_test.go
+++ b/ast/filter_test.go
@@ -1,0 +1,81 @@
+/*
+ * Copyright (c) 2026 The XGo Authors (xgo.dev). All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ast_test
+
+import (
+	"slices"
+	"testing"
+
+	"github.com/goplus/xgo/ast"
+	"github.com/goplus/xgo/parser"
+	"github.com/goplus/xgo/token"
+)
+
+func TestFileExportsEnumType(t *testing.T) {
+	fset := token.NewFileSet()
+	file, err := parser.ParseFile(fset, "enum.xgo", []byte(`package p
+
+type Color const (
+	Red = iota
+	green
+	Blue
+)
+
+type hidden const (
+	Shown = iota
+	hiddenValue
+)
+`), 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if !ast.FileExports(file) {
+		t.Fatal("FileExports reported no exported declarations")
+	}
+
+	names := enumValueNames(t, file, "Color")
+	if want := []string{"Red", "Blue"}; !slices.Equal(names, want) {
+		t.Fatalf("exported enum values = %q, want %q", names, want)
+	}
+}
+
+func enumValueNames(t *testing.T, file *ast.File, typeName string) []string {
+	t.Helper()
+
+	var names []string
+	for _, decl := range file.Decls {
+		gen, ok := decl.(*ast.GenDecl)
+		if !ok {
+			continue
+		}
+		for _, spec := range gen.Specs {
+			typeSpec, ok := spec.(*ast.TypeSpec)
+			if !ok || typeSpec.Name.Name != typeName {
+				continue
+			}
+			enumType := typeSpec.Type.(*ast.EnumType)
+			for _, spec := range enumType.Specs {
+				valueSpec := spec.(*ast.ValueSpec)
+				names = append(names, valueSpec.Names[0].Name)
+			}
+			return names
+		}
+	}
+	t.Fatalf("enum type %q not found", typeName)
+	return nil
+}

--- a/ast/walk.go
+++ b/ast/walk.go
@@ -90,15 +90,8 @@ func Walk(v Visitor, node Node) {
 
 	case *DomainTextLit:
 		Walk(v, n.Domain)
-		if e := n.Extra; e != nil {
-			switch e := e.(type) {
-			case *StringLitEx:
-				for _, part := range e.Parts {
-					if e, ok := part.(Expr); ok {
-						Walk(v, e)
-					}
-				}
-			}
+		if e, ok := n.Extra.(*DomainTextLitEx); ok {
+			walkList(v, e.Args)
 		}
 
 	case *Ellipsis:
@@ -336,6 +329,9 @@ func Walk(v Visitor, node Node) {
 			Walk(v, n.Type)
 		}
 		walkList(v, n.Values)
+		if n.Tag != nil {
+			Walk(v, n.Tag)
+		}
 		if n.Comment != nil {
 			Walk(v, n.Comment)
 		}
@@ -405,6 +401,14 @@ func Walk(v Visitor, node Node) {
 	case *TupleLit:
 		walkList(v, n.Elts)
 
+	case *MatrixLit:
+		for _, row := range n.Elts {
+			walkList(v, row)
+		}
+
+	case *ElemEllipsis:
+		Walk(v, n.Elt)
+
 	case *LambdaExpr:
 		walkList(v, n.Lhs)
 		walkList(v, n.Rhs)
@@ -420,13 +424,13 @@ func Walk(v Visitor, node Node) {
 		if n.Value != nil {
 			Walk(v, n.Value)
 		}
+		Walk(v, n.X)
 		if n.Init != nil {
 			Walk(v, n.Init)
 		}
 		if n.Cond != nil {
 			Walk(v, n.Cond)
 		}
-		Walk(v, n.X)
 
 	case *ComprehensionExpr:
 		if n.Elt != nil {

--- a/ast/walk_test.go
+++ b/ast/walk_test.go
@@ -1,0 +1,152 @@
+/*
+ * Copyright (c) 2026 The XGo Authors (xgo.dev). All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ast
+
+import (
+	"slices"
+	"testing"
+)
+
+func walkedNodeNames(node Node) (names []string, depth int) {
+	Inspect(node, func(n Node) bool {
+		if n == nil {
+			depth--
+			return true
+		}
+		depth++
+		switch n := n.(type) {
+		case *DomainTextLit:
+			names = append(names, "DomainTextLit")
+		case *MatrixLit:
+			names = append(names, "MatrixLit")
+		case *ElemEllipsis:
+			names = append(names, "ElemEllipsis")
+		case *ValueSpec:
+			names = append(names, "ValueSpec")
+		case *ForPhrase:
+			names = append(names, "ForPhrase")
+		case *ExprStmt:
+			names = append(names, "ExprStmt")
+		case *Ident:
+			names = append(names, n.Name)
+		case *BasicLit:
+			names = append(names, n.Value)
+		}
+		return true
+	})
+	return names, depth
+}
+
+func TestWalkMatrixLit(t *testing.T) {
+	matrixLit := &MatrixLit{
+		Elts: [][]Expr{
+			{
+				&Ident{Name: "a"},
+				&Ident{Name: "b"},
+			},
+			{
+				&ElemEllipsis{Elt: &Ident{Name: "row"}},
+			},
+		},
+	}
+
+	visited, depth := walkedNodeNames(matrixLit)
+	if depth != 0 {
+		t.Fatalf("got traversal depth %d, want 0", depth)
+	}
+	if want := []string{"MatrixLit", "a", "b", "ElemEllipsis", "row"}; !slices.Equal(visited, want) {
+		t.Fatalf("visited nodes = %q, want %q", visited, want)
+	}
+}
+
+func TestWalkMatrixLitPrune(t *testing.T) {
+	matrixLit := &MatrixLit{
+		Elts: [][]Expr{
+			{
+				&Ident{Name: "a"},
+				&ElemEllipsis{Elt: &Ident{Name: "row"}},
+			},
+		},
+	}
+
+	var sawMatrixLit bool
+	var sawIdent bool
+	Inspect(matrixLit, func(n Node) bool {
+		switch n.(type) {
+		case *MatrixLit:
+			sawMatrixLit = true
+			return false
+		case *Ident:
+			sawIdent = true
+		}
+		return true
+	})
+
+	if !sawMatrixLit {
+		t.Fatal("MatrixLit was not visited")
+	}
+	if sawIdent {
+		t.Fatal("pruned MatrixLit still visited an identifier")
+	}
+}
+
+func TestWalkDomainTextLitEx(t *testing.T) {
+	domainTextLit := &DomainTextLit{
+		Domain: &Ident{Name: "huh"},
+		Extra: &DomainTextLitEx{
+			Args: []Expr{
+				&Ident{Name: "ret"},
+				&CallExpr{
+					Fun:  &Ident{Name: "make"},
+					Args: []Expr{&Ident{Name: "arg"}},
+				},
+			},
+		},
+	}
+
+	visited, _ := walkedNodeNames(domainTextLit)
+	if want := []string{"DomainTextLit", "huh", "ret", "make", "arg"}; !slices.Equal(visited, want) {
+		t.Fatalf("visited nodes = %q, want %q", visited, want)
+	}
+}
+
+func TestWalkValueSpecTag(t *testing.T) {
+	valueSpec := &ValueSpec{
+		Names: []*Ident{{Name: "field"}},
+		Tag:   &BasicLit{Value: "`json:\"field\"`"},
+	}
+
+	visited, _ := walkedNodeNames(valueSpec)
+	if want := []string{"ValueSpec", "field", "`json:\"field\"`"}; !slices.Equal(visited, want) {
+		t.Fatalf("visited nodes = %q, want %q", visited, want)
+	}
+}
+
+func TestWalkForPhraseSourceOrder(t *testing.T) {
+	forPhrase := &ForPhrase{
+		Key:   &Ident{Name: "k"},
+		Value: &Ident{Name: "v"},
+		X:     &Ident{Name: "items"},
+		Init:  &ExprStmt{X: &Ident{Name: "init"}},
+		Cond:  &Ident{Name: "cond"},
+	}
+
+	visited, _ := walkedNodeNames(forPhrase)
+	if want := []string{"ForPhrase", "k", "v", "items", "ExprStmt", "init", "cond"}; !slices.Equal(visited, want) {
+		t.Fatalf("visited nodes = %q, want %q", visited, want)
+	}
+}

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -2536,6 +2536,7 @@ func (p *parser) checkExpr(x ast.Expr) ast.Expr {
 	case *ast.LambdaExpr:
 	case *ast.LambdaExpr2:
 	case *ast.TupleLit:
+	case *ast.MatrixLit:
 	case *ast.EnvExpr:
 	case *ast.CondExpr:
 	case *ast.ElemEllipsis:

--- a/parser/parser_test.go
+++ b/parser/parser_test.go
@@ -378,6 +378,7 @@ func TestCheckExpr(t *testing.T) {
 	p.init(token.NewFileSet(), "/foo/bar.xgo", []byte(``), 0)
 	p.checkExpr(&ast.Ellipsis{})
 	p.checkExpr(&ast.ElemEllipsis{})
+	p.checkExpr(&ast.MatrixLit{})
 	p.checkExpr(&ast.StarExpr{})
 	p.checkExpr(&ast.IndexListExpr{})
 	p.checkExpr(&ast.FuncType{})

--- a/x/format/gopstyle.go
+++ b/x/format/gopstyle.go
@@ -176,7 +176,7 @@ func (ctx *formatCtx) leaveBlock(old *types.Scope) {
 }
 
 func formatFile(file *ast.File) {
-	var funcs []*ast.FuncDecl
+	var funcs []ast.Decl
 	ctx := &formatCtx{
 		imports: make(map[string]*importCtx),
 		scope:   types.NewScope(nil, token.NoPos, token.NoPos, ""),
@@ -185,6 +185,8 @@ func formatFile(file *ast.File) {
 		switch v := decl.(type) {
 		case *ast.FuncDecl:
 			// delay the process, because package level vars need to be processed first.
+			funcs = append(funcs, v)
+		case *ast.OverloadFuncDecl:
 			funcs = append(funcs, v)
 		case *ast.GenDecl:
 			switch v.Tok {
@@ -210,7 +212,12 @@ func formatFile(file *ast.File) {
 	}
 
 	for _, fn := range funcs {
-		formatFuncDecl(ctx, fn)
+		switch v := fn.(type) {
+		case *ast.FuncDecl:
+			formatFuncDecl(ctx, v)
+		case *ast.OverloadFuncDecl:
+			formatOverloadFuncDecl(ctx, v)
+		}
 	}
 	for _, imp := range ctx.imports {
 		if imp.pkgPath == "fmt" && !imp.isUsed {
@@ -228,8 +235,7 @@ func formatGenDecl(ctx *formatCtx, v *ast.GenDecl) {
 	case token.VAR, token.CONST:
 		for _, item := range v.Specs {
 			spec := item.(*ast.ValueSpec)
-			formatType(ctx, spec.Type, &spec.Type)
-			formatExprs(ctx, spec.Values)
+			formatValueSpec(ctx, spec)
 			for _, name := range spec.Names {
 				ctx.insert(name.Name)
 			}
@@ -242,9 +248,24 @@ func formatGenDecl(ctx *formatCtx, v *ast.GenDecl) {
 	}
 }
 
+func formatValueSpec(ctx *formatCtx, spec *ast.ValueSpec) {
+	formatType(ctx, spec.Type, &spec.Type)
+	formatBasicLit(ctx, spec.Tag)
+	formatExprs(ctx, spec.Values)
+}
+
 func formatFuncDecl(ctx *formatCtx, v *ast.FuncDecl) {
+	for _, dec := range v.Decorators {
+		formatCallExpr(ctx, &dec.CallExpr)
+	}
+	formatFields(ctx, v.Recv)
 	formatFuncType(ctx, v.Type)
 	formatBlockStmt(ctx, v.Body)
+}
+
+func formatOverloadFuncDecl(ctx *formatCtx, v *ast.OverloadFuncDecl) {
+	formatFields(ctx, v.Recv)
+	formatExprs(ctx, v.Funcs)
 }
 
 /*

--- a/x/format/gopstyle_test.go
+++ b/x/format/gopstyle_test.go
@@ -123,6 +123,190 @@ func f() {
 `)
 }
 
+func TestMatrixLit(t *testing.T) {
+	testFormat(t, "matrix literal", `package main
+
+import "fmt"
+
+func main() {
+	fmt.Println([
+		fmt.Sprint(1), 2
+		3, 4
+	])
+}
+`, `echo [
+	sprint(1), 2
+	3, 4
+]
+`)
+}
+
+func TestEnumType(t *testing.T) {
+	testFormat(t, "enum type", `package main
+
+import "fmt"
+
+type Status const (
+	Started = fmt.Sprint(1)
+	Stopped = fmt.Sprintf("%d", 2)
+)
+`, `type Status const (
+	Started = sprint(1)
+	Stopped = sprintf("%d", 2)
+)
+`)
+}
+
+func TestTupleType(t *testing.T) {
+	testFormat(t, "tuple type", `package main
+
+import "fmt"
+
+var _ (fmt.Stringer, int)
+`, `import "fmt"
+
+var _ (fmt.Stringer, int)
+`)
+}
+
+func TestTupleLit(t *testing.T) {
+	testFormat(t, "tuple literal", `package main
+
+import "fmt"
+
+var _ = (fmt.Sprint(1), fmt.Sprintf("%d", 2))
+`, `var _ = (sprint(1), sprintf("%d", 2))
+`)
+}
+
+func TestIndexListExpr(t *testing.T) {
+	testFormat(t, "index list expression", `package main
+
+import "fmt"
+
+func f() {
+	_ = values[fmt.Stringer, fmt.GoStringer]
+}
+`, `import "fmt"
+
+func f() {
+	_ = values[fmt.Stringer, fmt.GoStringer]
+}
+`)
+}
+
+func TestCallKwargs(t *testing.T) {
+	testFormat(t, "call kwargs", `package main
+
+import "fmt"
+
+func f() {
+	_ = render(msg=fmt.Sprint(1))
+	_ = render(msg=fmt.Sprint(1), cb=func() string {
+		return fmt.Sprint(2)
+	})
+}
+`, `func f() {
+	_ = render(msg = sprint(1))
+	_ = render(msg = sprint(1), cb = => sprint(2))
+}
+`)
+}
+
+func TestForStmtPost(t *testing.T) {
+	testFormat(t, "for statement post", `package main
+
+import "fmt"
+
+func f() {
+	for i := 0; i < 1; fmt.Sprint(i) {
+	}
+}
+`, `func f() {
+	for i := 0; i < 1; sprint(i) {
+	}
+}
+`)
+}
+
+func TestOverloadFuncDecl(t *testing.T) {
+	testFormat(t, "overload function declaration", `package main
+
+import "fmt"
+
+func F = (
+	(fmt).Sprint
+)
+`, `func F = (
+	sprint
+)
+`)
+}
+
+func TestCondExpr(t *testing.T) {
+	testFormat(t, "cond expr", `package main
+
+import "fmt"
+
+var _ = fmt.Sprint(1) @(fmt.Sprintf("%d", 2))
+`, `var _ = sprint(1)@(sprintf("%d", 2))
+`)
+}
+
+func TestStringLitExKeepsFmtImport(t *testing.T) {
+	testFormat(t, "string literal extra import", `package main
+
+import "fmt"
+
+var _ = "${fmt.Sprint(1)}"
+`, `import "fmt"
+
+var _ = "${fmt.Sprint(1)}"
+`)
+}
+
+func TestDomainTextLitExKeepsFmtImport(t *testing.T) {
+	src := "package main\n\nimport \"fmt\"\n\nvar _ = txt`> fmt.Sprint(1)\nbody\n`\n"
+	expect := "import \"fmt\"\n\nvar _ = txt`> fmt.Sprint(1)\nbody\n`\n"
+	testFormat(t, "domain text literal extra import", src, expect)
+}
+
+func TestTplLitRetProcKeepsFmtImport(t *testing.T) {
+	src := "package main\n\nimport \"fmt\"\n\nvar _ = tpl`\nexpr = INT => {\n\treturn fmt.Sprint(this)\n}\n`\n"
+	expect := "import \"fmt\"\n\nvar _ = tpl`\nexpr = INT => {\n\treturn fmt.Sprint(this)\n}\n`\n"
+	testFormat(t, "tpl literal return procedure import", src, expect)
+}
+
+func TestFuncDecoratorArgs(t *testing.T) {
+	testFormat(t, "func decorator args", `package main
+
+import "fmt"
+
+@retry(fmt.Sprint(1), func() string {
+	return fmt.Sprintln("x")
+})
+func f() {
+}
+`, `@retry(sprint(1), => sprintln("x"))
+func f() {
+}
+`)
+}
+
+func TestFuncReceiverKeepImport(t *testing.T) {
+	testFormat(t, "func receiver import", `package main
+
+import "fmt"
+
+func (v fmt.Stringer) f() {
+}
+`, `import "fmt"
+
+func (v fmt.Stringer) f() {
+}
+`)
+}
+
 func TestPrintln(t *testing.T) {
 	testFormat(t, "print", `package main
 

--- a/x/format/stmt_expr_or_type.go
+++ b/x/format/stmt_expr_or_type.go
@@ -22,6 +22,7 @@ import (
 	"reflect"
 
 	"github.com/goplus/xgo/ast"
+	tplast "github.com/goplus/xgo/tpl/ast"
 )
 
 // -----------------------------------------------------------------------------
@@ -49,12 +50,17 @@ func formatType(ctx *formatCtx, typ ast.Expr, ref *ast.Expr) {
 		formatFuncType(ctx, t)
 	case *ast.Ellipsis:
 		formatType(ctx, t.Elt, &t.Elt)
+	case *ast.TupleType:
+		formatFields(ctx, t.Fields)
+	case *ast.EnumType:
+		formatEnumType(ctx, t)
 	default:
 		log.Panicln("TODO: format -", reflect.TypeOf(typ))
 	}
 }
 
 func formatFuncType(ctx *formatCtx, t *ast.FuncType) {
+	formatFields(ctx, t.TypeParams)
 	formatFields(ctx, t.Params)
 	formatFields(ctx, t.Results)
 }
@@ -81,7 +87,9 @@ func formatExprs(ctx *formatCtx, exprs []ast.Expr) {
 
 func formatExpr(ctx *formatCtx, expr ast.Expr, ref *ast.Expr) {
 	switch v := expr.(type) {
-	case *ast.Ident, *ast.BasicLit, *ast.BadExpr, nil:
+	case *ast.Ident, *ast.BadExpr, nil:
+	case *ast.BasicLit:
+		formatBasicLit(ctx, v)
 	case *ast.BinaryExpr:
 		formatExpr(ctx, v.X, &v.X)
 		formatExpr(ctx, v.Y, &v.Y)
@@ -91,13 +99,24 @@ func formatExpr(ctx *formatCtx, expr ast.Expr, ref *ast.Expr) {
 		formatCallExpr(ctx, v)
 	case *ast.SelectorExpr:
 		formatSelectorExpr(ctx, v, ref)
+	case *ast.AnySelectorExpr:
+		formatExpr(ctx, v.X, &v.X)
 	case *ast.SliceExpr:
 		formatSliceExpr(ctx, v)
 	case *ast.IndexExpr:
 		formatExpr(ctx, v.X, &v.X)
 		formatExpr(ctx, v.Index, &v.Index)
+	case *ast.IndexListExpr:
+		formatExpr(ctx, v.X, &v.X)
+		formatExprs(ctx, v.Indices)
 	case *ast.SliceLit:
 		formatExprs(ctx, v.Elts)
+	case *ast.TupleLit:
+		formatExprs(ctx, v.Elts)
+	case *ast.MatrixLit:
+		for _, row := range v.Elts {
+			formatExprs(ctx, row)
+		}
 	case *ast.CompositeLit:
 		formatType(ctx, v.Type, &v.Type)
 		formatExprs(ctx, v.Elts)
@@ -106,6 +125,8 @@ func formatExpr(ctx *formatCtx, expr ast.Expr, ref *ast.Expr) {
 	case *ast.KeyValueExpr:
 		formatExpr(ctx, v.Key, &v.Key)
 		formatExpr(ctx, v.Value, &v.Value)
+	case *ast.KwargExpr:
+		formatCallArg(ctx, &v.Value)
 	case *ast.FuncLit:
 		formatFuncType(ctx, v.Type)
 		formatBlockStmt(ctx, v.Body)
@@ -120,6 +141,8 @@ func formatExpr(ctx *formatCtx, expr ast.Expr, ref *ast.Expr) {
 		formatRangeExpr(ctx, v)
 	case *ast.ComprehensionExpr:
 		formatComprehensionExpr(ctx, v)
+	case *ast.ForPhrase:
+		formatForPhrase(ctx, v)
 	case *ast.ErrWrapExpr:
 		formatExpr(ctx, v.X, &v.X)
 		formatExpr(ctx, v.Default, &v.Default)
@@ -127,9 +150,97 @@ func formatExpr(ctx *formatCtx, expr ast.Expr, ref *ast.Expr) {
 		formatExpr(ctx, v.X, &v.X)
 	case *ast.Ellipsis:
 		formatExpr(ctx, v.Elt, &v.Elt)
+	case *ast.ElemEllipsis:
+		formatExpr(ctx, v.Elt, &v.Elt)
+	case *ast.DomainTextLit:
+		switch lit := v.Extra.(type) {
+		case *ast.DomainTextLitEx:
+			for _, arg := range lit.Args {
+				markExprImports(ctx, arg)
+			}
+		case *tplast.File:
+			markTplRetProcImports(ctx, lit)
+		}
+	case *ast.NumberUnitLit, *ast.EnvExpr:
+	case *ast.CondExpr:
+		formatExpr(ctx, v.X, &v.X)
+		formatExpr(ctx, v.Cond, &v.Cond)
 	default:
 		formatType(ctx, expr, ref)
 	}
+}
+
+func formatEnumType(ctx *formatCtx, v *ast.EnumType) {
+	for _, spec := range v.Specs {
+		if value, ok := spec.(*ast.ValueSpec); ok {
+			formatValueSpec(ctx, value)
+		}
+	}
+}
+
+func formatBasicLit(ctx *formatCtx, v *ast.BasicLit) {
+	if v == nil || v.Extra == nil {
+		return
+	}
+	for _, part := range v.Extra.Parts {
+		if expr, ok := part.(ast.Expr); ok {
+			markExprImports(ctx, expr)
+		}
+	}
+}
+
+func markExprImports(ctx *formatCtx, expr ast.Expr) {
+	if expr == nil {
+		return
+	}
+	ast.Inspect(expr, func(node ast.Node) bool {
+		if sel, ok := node.(*ast.SelectorExpr); ok {
+			markSelectorImport(ctx, sel)
+		}
+		return true
+	})
+}
+
+func markTplRetProcImports(ctx *formatCtx, file *tplast.File) {
+	for _, decl := range file.Decls {
+		rule, ok := decl.(*tplast.Rule)
+		if !ok {
+			continue
+		}
+		expr, ok := rule.RetProc.(ast.Expr)
+		if !ok {
+			continue
+		}
+		markExprImports(ctx, expr)
+	}
+}
+
+func markSelectorImport(ctx *formatCtx, v *ast.SelectorExpr) {
+	name, ok := selectorImportName(v.X)
+	if !ok {
+		return
+	}
+	if imp, ok := unshadowedImport(ctx, name); ok {
+		imp.isUsed = true
+	}
+}
+
+func selectorImportName(expr ast.Expr) (string, bool) {
+	switch x := expr.(type) {
+	case *ast.Ident:
+		return x.Name, true
+	case *ast.ParenExpr:
+		return selectorImportName(x.X)
+	}
+	return "", false
+}
+
+func unshadowedImport(ctx *formatCtx, name string) (*importCtx, bool) {
+	if _, o := ctx.scope.LookupParent(name, token.NoPos); o != nil {
+		return nil, false
+	}
+	imp, ok := ctx.imports[name]
+	return imp, ok
 }
 
 func formatRangeExpr(ctx *formatCtx, v *ast.RangeExpr) {
@@ -168,27 +279,32 @@ func formatSliceExpr(ctx *formatCtx, v *ast.SliceExpr) {
 func formatCallExpr(ctx *formatCtx, v *ast.CallExpr) {
 	formatExpr(ctx, v.Fun, &v.Fun)
 	fncallStartingLowerCase(v)
-	for i, arg := range v.Args {
-		if fn, ok := arg.(*ast.FuncLit); ok {
-			funcLitToLambdaExpr(fn, &v.Args[i])
-		}
+	for i := range v.Args {
+		formatCallArg(ctx, &v.Args[i])
 	}
-	formatExprs(ctx, v.Args)
+	for _, arg := range v.Kwargs {
+		formatCallArg(ctx, &arg.Value)
+	}
+}
+
+func formatCallArg(ctx *formatCtx, arg *ast.Expr) {
+	if fn, ok := (*arg).(*ast.FuncLit); ok {
+		funcLitToLambdaExpr(fn, arg)
+	}
+	formatExpr(ctx, *arg, arg)
 }
 
 func formatSelectorExpr(ctx *formatCtx, v *ast.SelectorExpr, ref *ast.Expr) {
-	switch x := v.X.(type) {
-	case *ast.Ident:
-		if _, o := ctx.scope.LookupParent(x.Name, token.NoPos); o != nil {
-			break
-		}
-		if imp, ok := ctx.imports[x.Name]; ok {
-			if !fmtToBuiltin(imp, v.Sel, ref) {
-				imp.isUsed = true
-			}
-		}
-	default:
-		formatExpr(ctx, x, &v.X)
+	if name, ok := selectorImportName(v.X); ok {
+		formatImportSelector(ctx, name, v.Sel, ref)
+		return
+	}
+	formatExpr(ctx, v.X, &v.X)
+}
+
+func formatImportSelector(ctx *formatCtx, name string, sel *ast.Ident, ref *ast.Expr) {
+	if imp, ok := unshadowedImport(ctx, name); ok && !fmtToBuiltin(imp, sel, ref) {
+		imp.isUsed = true
 	}
 }
 
@@ -259,6 +375,14 @@ func formatStmt(ctx *formatCtx, stmt ast.Stmt) {
 	}
 }
 
+func formatHeaderStmt(ctx *formatCtx, stmt ast.Stmt) {
+	if exprStmt, ok := stmt.(*ast.ExprStmt); ok {
+		formatExpr(ctx, exprStmt.X, &exprStmt.X)
+		return
+	}
+	formatStmt(ctx, stmt)
+}
+
 func formatExprStmt(ctx *formatCtx, v *ast.ExprStmt) {
 	switch x := v.X.(type) {
 	case *ast.CallExpr:
@@ -276,7 +400,7 @@ func formatSwitchStmt(ctx *formatCtx, v *ast.SwitchStmt) {
 	old := ctx.enterBlock()
 	defer ctx.leaveBlock(old)
 
-	formatStmt(ctx, v.Init)
+	formatHeaderStmt(ctx, v.Init)
 	formatExpr(ctx, v.Tag, &v.Tag)
 	formatBlockStmt(ctx, v.Body)
 }
@@ -285,8 +409,8 @@ func formatTypeSwitchStmt(ctx *formatCtx, v *ast.TypeSwitchStmt) {
 	old := ctx.enterBlock()
 	defer ctx.leaveBlock(old)
 
-	formatStmt(ctx, v.Init)
-	formatStmt(ctx, v.Assign)
+	formatHeaderStmt(ctx, v.Init)
+	formatHeaderStmt(ctx, v.Assign)
 	formatBlockStmt(ctx, v.Body)
 }
 
@@ -294,7 +418,7 @@ func formatIfStmt(ctx *formatCtx, v *ast.IfStmt) {
 	old := ctx.enterBlock()
 	defer ctx.leaveBlock(old)
 
-	formatStmt(ctx, v.Init)
+	formatHeaderStmt(ctx, v.Init)
 	formatExpr(ctx, v.Cond, &v.Cond)
 	formatBlockStmt(ctx, v.Body)
 	formatStmt(ctx, v.Else)
@@ -322,8 +446,9 @@ func formatForStmt(ctx *formatCtx, v *ast.ForStmt) {
 	old := ctx.enterBlock()
 	defer ctx.leaveBlock(old)
 
-	formatStmt(ctx, v.Init)
+	formatHeaderStmt(ctx, v.Init)
 	formatExpr(ctx, v.Cond, &v.Cond)
+	formatHeaderStmt(ctx, v.Post)
 	formatBlockStmt(ctx, v.Body)
 }
 

--- a/x/format/stmt_expr_or_type_test.go
+++ b/x/format/stmt_expr_or_type_test.go
@@ -1,0 +1,237 @@
+/*
+ * Copyright (c) 2026 The XGo Authors (xgo.dev). All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package format
+
+import (
+	"go/types"
+	"slices"
+	"testing"
+
+	"github.com/goplus/xgo/ast"
+	"github.com/goplus/xgo/token"
+)
+
+func newFormatTestCtx() *formatCtx {
+	return &formatCtx{
+		imports: map[string]*importCtx{
+			"fmt": {pkgPath: "fmt"},
+		},
+		scope: types.NewScope(nil, token.NoPos, token.NoPos, ""),
+	}
+}
+
+func fmtCallExpr(name string, args ...ast.Expr) *ast.CallExpr {
+	return &ast.CallExpr{
+		Fun: &ast.SelectorExpr{
+			X:   ast.NewIdent("fmt"),
+			Sel: ast.NewIdent(name),
+		},
+		Args: args,
+	}
+}
+
+func formattedCallName(t *testing.T, expr ast.Expr) string {
+	t.Helper()
+	call, ok := expr.(*ast.CallExpr)
+	if !ok {
+		t.Fatalf("expression = %T, want *ast.CallExpr", expr)
+	}
+	name, ok := call.Fun.(*ast.Ident)
+	if !ok {
+		t.Fatalf("call function = %T, want *ast.Ident", call.Fun)
+	}
+	return name.Name
+}
+
+func formattedLambdaCallName(t *testing.T, expr ast.Expr) string {
+	t.Helper()
+	lambda, ok := expr.(*ast.LambdaExpr)
+	if !ok {
+		t.Fatalf("expression = %T, want *ast.LambdaExpr", expr)
+	}
+	if len(lambda.Rhs) != 1 {
+		t.Fatalf("lambda rhs length = %d, want 1", len(lambda.Rhs))
+	}
+	return formattedCallName(t, lambda.Rhs[0])
+}
+
+func TestFormatExtensionExprBranches(t *testing.T) {
+	for _, tt := range []struct {
+		name string
+		expr ast.Expr
+		got  func(*testing.T, ast.Expr) []string
+		want []string
+	}{
+		{
+			name: "ForPhrase",
+			expr: &ast.ForPhrase{
+				X: fmtCallExpr("Sprint", &ast.BasicLit{Kind: token.INT, Value: "1"}),
+				Cond: fmtCallExpr(
+					"Sprintf",
+					&ast.BasicLit{Kind: token.STRING, Value: `"%d"`},
+					&ast.BasicLit{Kind: token.INT, Value: "2"},
+				),
+			},
+			got: func(t *testing.T, expr ast.Expr) []string {
+				forPhrase := expr.(*ast.ForPhrase)
+				return []string{
+					formattedCallName(t, forPhrase.X),
+					formattedCallName(t, forPhrase.Cond),
+				}
+			},
+			want: []string{"sprint", "sprintf"},
+		},
+		{
+			name: "KwargExpr",
+			expr: &ast.KwargExpr{
+				Name:  ast.NewIdent("msg"),
+				Value: fmtCallExpr("Sprint", &ast.BasicLit{Kind: token.INT, Value: "1"}),
+			},
+			got: func(t *testing.T, expr ast.Expr) []string {
+				return []string{formattedCallName(t, expr.(*ast.KwargExpr).Value)}
+			},
+			want: []string{"sprint"},
+		},
+		{
+			name: "KwargExprFuncLit",
+			expr: &ast.KwargExpr{
+				Name: ast.NewIdent("cb"),
+				Value: &ast.FuncLit{
+					Type: &ast.FuncType{
+						Params: &ast.FieldList{},
+						Results: &ast.FieldList{List: []*ast.Field{
+							{Type: ast.NewIdent("string")},
+						}},
+					},
+					Body: &ast.BlockStmt{List: []ast.Stmt{
+						&ast.ReturnStmt{Results: []ast.Expr{
+							fmtCallExpr("Sprint", &ast.BasicLit{Kind: token.INT, Value: "1"}),
+						}},
+					}},
+				},
+			},
+			got: func(t *testing.T, expr ast.Expr) []string {
+				return []string{formattedLambdaCallName(t, expr.(*ast.KwargExpr).Value)}
+			},
+			want: []string{"sprint"},
+		},
+		{
+			name: "ElemEllipsis",
+			expr: &ast.ElemEllipsis{
+				Elt: fmtCallExpr("Sprint", &ast.BasicLit{Kind: token.INT, Value: "1"}),
+			},
+			got: func(t *testing.T, expr ast.Expr) []string {
+				return []string{formattedCallName(t, expr.(*ast.ElemEllipsis).Elt)}
+			},
+			want: []string{"sprint"},
+		},
+		{
+			name: "AnySelectorExpr",
+			expr: &ast.AnySelectorExpr{
+				X:   fmtCallExpr("Sprint", &ast.BasicLit{Kind: token.INT, Value: "1"}),
+				Sel: ast.NewIdent("name"),
+			},
+			got: func(t *testing.T, expr ast.Expr) []string {
+				return []string{formattedCallName(t, expr.(*ast.AnySelectorExpr).X)}
+			},
+			want: []string{"sprint"},
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := newFormatTestCtx()
+			expr := tt.expr
+			formatExpr(ctx, expr, &expr)
+			if got := tt.got(t, expr); !slices.Equal(got, tt.want) {
+				t.Fatalf("formatted call names = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestFormatFuncTypeTypeParams(t *testing.T) {
+	ctx := newFormatTestCtx()
+	formatFuncType(ctx, &ast.FuncType{
+		TypeParams: &ast.FieldList{List: []*ast.Field{
+			{
+				Names: []*ast.Ident{ast.NewIdent("T")},
+				Type: &ast.SelectorExpr{
+					X:   ast.NewIdent("fmt"),
+					Sel: ast.NewIdent("Stringer"),
+				},
+			},
+		}},
+		Params: &ast.FieldList{},
+	})
+	if !ctx.imports["fmt"].isUsed {
+		t.Fatal("type parameter constraint didn't mark fmt import as used")
+	}
+}
+
+func TestMarkExprImports(t *testing.T) {
+	t.Run("NilExpr", func(t *testing.T) {
+		ctx := newFormatTestCtx()
+		markExprImports(ctx, nil)
+		if ctx.imports["fmt"].isUsed {
+			t.Fatal("nil expression marked fmt import as used")
+		}
+	})
+
+	t.Run("NonIdentifierSelector", func(t *testing.T) {
+		ctx := newFormatTestCtx()
+		markExprImports(ctx, &ast.SelectorExpr{
+			X:   &ast.BasicLit{Kind: token.STRING, Value: `"fmt"`},
+			Sel: ast.NewIdent("Stringer"),
+		})
+		if ctx.imports["fmt"].isUsed {
+			t.Fatal("non-identifier selector marked fmt import as used")
+		}
+	})
+
+	t.Run("ShadowedImportName", func(t *testing.T) {
+		ctx := newFormatTestCtx()
+		ctx.insert("fmt")
+		markExprImports(ctx, &ast.SelectorExpr{
+			X:   ast.NewIdent("fmt"),
+			Sel: ast.NewIdent("Stringer"),
+		})
+		if ctx.imports["fmt"].isUsed {
+			t.Fatal("scoped fmt identifier marked fmt import as used")
+		}
+	})
+
+	t.Run("ImportedSelector", func(t *testing.T) {
+		ctx := newFormatTestCtx()
+		markExprImports(ctx, &ast.SelectorExpr{
+			X:   ast.NewIdent("fmt"),
+			Sel: ast.NewIdent("Stringer"),
+		})
+		if !ctx.imports["fmt"].isUsed {
+			t.Fatal("fmt selector didn't mark fmt import as used")
+		}
+	})
+
+	t.Run("ParenthesizedImportedSelector", func(t *testing.T) {
+		ctx := newFormatTestCtx()
+		markExprImports(ctx, &ast.SelectorExpr{
+			X:   &ast.ParenExpr{X: ast.NewIdent("fmt")},
+			Sel: ast.NewIdent("Stringer"),
+		})
+		if !ctx.imports["fmt"].isUsed {
+			t.Fatal("parenthesized fmt selector didn't mark fmt import as used")
+		}
+	})
+}


### PR DESCRIPTION
Shared AST utilities, expression validation, and smart formatting had not kept pace with XGo-specific syntax nodes added over time. Matrix literal parsing fixes in #2755 exposed one of those gaps, where valid matrix nodes could reach traversal and formatting paths that did not handle them consistently.

Walk embedded expressions in domain text literals, class field tags, matrix literals, and element ellipses, and keep for-phrase traversal in source order. Preserve exported enum values in `FileExports`.

Allow matrix literals in parser expression validation and recurse through XGo expression, type, decorator, receiver, and tag nodes during smart formatting so imports are kept or removed based on actual use.

Updates #2755
