### PR TITLE
feat(projectdriver): dispatch class projects through verified drivers

### DIFF
--- a/cmd/internal/base/pass.go
+++ b/cmd/internal/base/pass.go
@@ -78,6 +78,7 @@ func PassBuildFlags(cmd *Command) *PassArgs {
 		"trimpath", "work")
 	p.Var("p", "asmflags", "compiler", "buildmode",
 		"gcflags", "gccgoflags", "installsuffix",
-		"ldflags", "pkgdir", "tags", "toolexec", "buildvcs")
+		"ldflags", "pkgdir", "tags", "toolexec", "buildvcs",
+		"mod", "modfile", "overlay")
 	return p
 }

--- a/cmd/internal/build/build.go
+++ b/cmd/internal/build/build.go
@@ -18,6 +18,7 @@
 package build
 
 import (
+	"context"
 	"fmt"
 	"log"
 	"os"
@@ -27,6 +28,7 @@ import (
 	"github.com/goplus/gogen"
 	"github.com/goplus/xgo/cl"
 	"github.com/goplus/xgo/cmd/internal/base"
+	"github.com/goplus/xgo/cmd/internal/projectdriver"
 	"github.com/goplus/xgo/tool"
 	"github.com/goplus/xgo/x/gocmd"
 	"github.com/goplus/xgo/x/xgoprojs"
@@ -54,7 +56,6 @@ func runCmd(cmd *base.Command, args []string) {
 	if err != nil {
 		log.Panicln("parse input arguments failed:", err)
 	}
-
 	if *flagDebug {
 		gogen.SetDebug(gogen.DbgFlagAll &^ gogen.DbgFlagComments)
 		cl.SetDebug(cl.DbgFlagAll)
@@ -72,6 +73,21 @@ func runCmd(cmd *base.Command, args []string) {
 	}
 	if len(args) != 0 {
 		log.Panicln("too many arguments:", args)
+	}
+	driverFlags := append([]string(nil), pass.Args...)
+	if *flagDebug {
+		driverFlags = append(driverFlags, "-debug=true")
+	}
+	driverResult, driverErr := projectdriver.TryBuild(context.Background(), "", proj, driverFlags, *flagOutput, projectdriver.Streams{})
+	if driverErr != nil {
+		fmt.Fprintln(os.Stderr, driverErr)
+		os.Exit(1)
+	}
+	if driverResult.Handled {
+		if !driverResult.Status.Success() {
+			projectdriver.Exit(driverResult.Status)
+		}
+		return
 	}
 
 	conf, err := tool.NewDefaultConf(".", tool.ConfFlagNoTestFiles, pass.Tags())

--- a/cmd/internal/install/install.go
+++ b/cmd/internal/install/install.go
@@ -18,6 +18,7 @@
 package install
 
 import (
+	"context"
 	"fmt"
 	"log"
 	"os"
@@ -27,6 +28,7 @@ import (
 	"github.com/goplus/mod/modfetch"
 	"github.com/goplus/xgo/cl"
 	"github.com/goplus/xgo/cmd/internal/base"
+	"github.com/goplus/xgo/cmd/internal/projectdriver"
 	"github.com/goplus/xgo/tool"
 	"github.com/goplus/xgo/x/gocmd"
 	"github.com/goplus/xgo/x/xgoprojs"
@@ -69,6 +71,21 @@ func runCmd(cmd *base.Command, args []string) {
 		gogen.SetDebug(gogen.DbgFlagAll &^ gogen.DbgFlagComments)
 		cl.SetDebug(cl.DbgFlagAll)
 		cl.SetDisableRecover(true)
+	}
+	driverFlags := append([]string(nil), pass.Args...)
+	if *flagDebug {
+		driverFlags = append(driverFlags, "-debug=true")
+	}
+	driverResult, driverErr := projectdriver.TryInstall(context.Background(), "", projs, driverFlags, projectdriver.Streams{})
+	if driverErr != nil {
+		fmt.Fprintln(os.Stderr, driverErr)
+		os.Exit(1)
+	}
+	if driverResult.Handled {
+		if !driverResult.Status.Success() {
+			projectdriver.Exit(driverResult.Status)
+		}
+		return
 	}
 
 	conf, err := tool.NewDefaultConf(".", tool.ConfFlagNoTestFiles, pass.Tags())

--- a/cmd/internal/projectdriver/cli_e2e_test.go
+++ b/cmd/internal/projectdriver/cli_e2e_test.go
@@ -1,0 +1,258 @@
+/*
+ * Copyright (c) 2026 The XGo Authors (xgo.dev). All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package projectdriver
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"testing"
+)
+
+func TestCLIEndToEnd(t *testing.T) {
+	if testing.Short() {
+		t.Skip("builds the XGo command and fake driver")
+	}
+	buildGoWork := os.Getenv("GOWORK")
+	modDir := protocolModuleDir(t, buildGoWork)
+	fixture := newDriverFixture(t)
+	configureSharedProtocolDriver(t, fixture, modDir)
+	goxmod := filepath.Join(fixture.framework, "gox.mod")
+	metadata, err := os.ReadFile(goxmod)
+	if err != nil {
+		t.Fatal(err)
+	}
+	metadata = []byte(strings.Replace(string(metadata), "pack pack index.data\n", "", 1))
+	if err := os.WriteFile(goxmod, metadata, 0644); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("FAKE_DRIVER_EXPECT_NO_PACK", "1")
+	repo, err := filepath.Abs(filepath.Join("..", "..", ".."))
+	if err != nil {
+		t.Fatal(err)
+	}
+	xgo := filepath.Join(t.TempDir(), executableName("xgo"))
+	build := exec.Command("go", "build", "-o", xgo, "./cmd/xgo")
+	build.Dir = repo
+	build.Env = replaceEnv(os.Environ(), "GOWORK", buildGoWork)
+	if output, err := build.CombinedOutput(); err != nil {
+		t.Fatalf("build XGo: %v\n%s", err, output)
+	}
+
+	run := cliCommand(xgo, repo, fixture.app, "run", "./game", "--", "", "a b", "--")
+	output, err := run.CombinedOutput()
+	if err != nil {
+		t.Fatalf("xgo run: %v\n%s", err, output)
+	}
+	if !strings.Contains(string(output), "run-args=|a b|--") {
+		t.Fatalf("xgo run output = %q", output)
+	}
+	assertNoAutogen(t, fixture.project)
+
+	artifact := filepath.Join(fixture.root, executableName("built-game"))
+	command := cliCommand(xgo, repo, fixture.app, "build", "-o", artifact, "./game")
+	if output, err := command.CombinedOutput(); err != nil {
+		t.Fatalf("xgo build: %v\n%s", err, output)
+	}
+	if info, err := os.Stat(artifact); err != nil || info.Size() == 0 {
+		t.Fatalf("built artifact = %#v, %v", info, err)
+	}
+	assertNoAutogen(t, fixture.project)
+
+	bin := filepath.Join(fixture.root, "install-bin")
+	install := cliCommand(xgo, repo, fixture.app, "install", "./game")
+	install.Env = append(install.Env, "GOBIN="+bin)
+	if output, err := install.CombinedOutput(); err != nil {
+		t.Fatalf("xgo install: %v\n%s", err, output)
+	}
+	installed := filepath.Join(bin, executableName("game"))
+	if info, err := os.Stat(installed); err != nil || info.Size() == 0 {
+		t.Fatalf("installed artifact = %#v, %v", info, err)
+	}
+
+	unsupported := []struct {
+		name string
+		args []string
+		flag string
+	}{
+		{name: "run debug", args: []string{"run", "-debug", "./game"}, flag: "-debug"},
+		{name: "run quiet", args: []string{"run", "-quiet", "./game"}, flag: "-quiet"},
+		{name: "build debug", args: []string{"build", "-debug", "-o", filepath.Join(fixture.root, "debug-build"), "./game"}, flag: "-debug"},
+		{name: "install debug", args: []string{"install", "-debug", "./game"}, flag: "-debug"},
+	}
+	for _, test := range unsupported {
+		t.Run(test.name, func(t *testing.T) {
+			marker := filepath.Join(fixture.root, strings.ReplaceAll(test.name, " ", "-")+"-started")
+			command := cliCommand(xgo, repo, fixture.app, test.args...)
+			command.Env = append(command.Env, "FAKE_DRIVER_MARKER="+marker)
+			output, err := command.CombinedOutput()
+			if err == nil || !strings.Contains(string(output), "does not support flag "+test.flag) {
+				t.Fatalf("command = %v\n%s", err, output)
+			}
+			if _, err := os.Stat(marker); !os.IsNotExist(err) {
+				t.Fatalf("driver started after rejected flag: %v", err)
+			}
+		})
+	}
+
+	marker := filepath.Join(fixture.root, "driver-started")
+	multiBin := filepath.Join(fixture.root, "multi-bin")
+	multi := cliCommand(xgo, repo, fixture.app, "install", "./game", "./game")
+	multi.Env = append(multi.Env, "GOBIN="+multiBin, "FAKE_DRIVER_MARKER="+marker)
+	output, err = multi.CombinedOutput()
+	if err == nil || !strings.Contains(string(output), "exactly one target") {
+		t.Fatalf("multi driver install = %v\n%s", err, output)
+	}
+	if _, err := os.Stat(marker); !os.IsNotExist(err) {
+		t.Fatalf("driver ran before multi-target rejection: %v", err)
+	}
+	if _, err := os.Stat(multiBin); !os.IsNotExist(err) {
+		t.Fatalf("install directory created before rejection: %v", err)
+	}
+
+	plain := filepath.Join(fixture.app, "plain")
+	mustMkdirAll(t, plain)
+	mustWriteFile(t, filepath.Join(plain, "main.go"), "package main\nfunc main() {}\n")
+	plainOutput := filepath.Join(fixture.root, executableName("plain"))
+	legacy := cliCommand(xgo, repo, fixture.app, "build", "-o", plainOutput, "./plain")
+	if output, err := legacy.CombinedOutput(); err != nil {
+		t.Fatalf("legacy build: %v\n%s", err, output)
+	}
+}
+
+func protocolModuleDir(t *testing.T, goWork string) string {
+	t.Helper()
+	command := exec.Command("go", "list", "-m", "-f={{.Dir}}", "github.com/goplus/mod")
+	command.Env = replaceEnv(os.Environ(), "GOWORK", goWork)
+	output, err := command.CombinedOutput()
+	if err != nil {
+		t.Fatalf("resolve github.com/goplus/mod source: %v\n%s", err, output)
+	}
+	dir := strings.TrimSpace(string(output))
+	if dir == "" {
+		t.Fatal("github.com/goplus/mod source directory is empty")
+	}
+	return canonicalDir(t, dir)
+}
+
+func configureSharedProtocolDriver(t *testing.T, fixture driverFixture, modDir string) {
+	t.Helper()
+	mustWriteFile(t, filepath.Join(fixture.framework, "cmd", "driver", "main.go"), protocolFakeDriverSource)
+	frameworkGoModPath := filepath.Join(fixture.framework, "go.mod")
+	frameworkGoMod, err := os.ReadFile(frameworkGoModPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	frameworkGoMod = append(frameworkGoMod, []byte("\nrequire github.com/goplus/mod v0.0.0\n")...)
+	if err := os.WriteFile(frameworkGoModPath, frameworkGoMod, 0644); err != nil {
+		t.Fatal(err)
+	}
+	goModPath := filepath.Join(fixture.app, "go.mod")
+	goMod, err := os.ReadFile(goModPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	goMod = append(goMod, []byte("\nrequire github.com/goplus/mod v0.0.0\n\nreplace github.com/goplus/mod => "+strconv.Quote(modDir)+"\n")...)
+	if err := os.WriteFile(goModPath, goMod, 0644); err != nil {
+		t.Fatal(err)
+	}
+	download := exec.Command("go", "mod", "download", "all")
+	download.Dir = fixture.app
+	download.Env = replaceEnv(os.Environ(), "GOWORK", "off")
+	if output, err := download.CombinedOutput(); err != nil {
+		t.Fatalf("prepare shared-protocol driver graph: %v\n%s", err, output)
+	}
+	goMod, err = os.ReadFile(goModPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(goMod), "example.test/framework v1.2.3 //xgo:class") {
+		t.Fatalf("fixture lost the class marker:\n%s", goMod)
+	}
+	if _, err := os.Stat(filepath.Join(fixture.app, "driverprotocol_tools.go")); !os.IsNotExist(err) {
+		t.Fatalf("fixture contains a test-only tools file: %v", err)
+	}
+}
+
+const protocolFakeDriverSource = `package main
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"runtime"
+	"strconv"
+	"strings"
+
+	"github.com/goplus/mod/driverprotocol"
+)
+
+func main() {
+	if marker := os.Getenv("FAKE_DRIVER_MARKER"); marker != "" {
+		_ = os.WriteFile(marker, []byte("started"), 0600)
+	}
+	if value := os.Getenv("FAKE_DRIVER_EXIT"); value != "" {
+		code, _ := strconv.Atoi(value)
+		os.Exit(code)
+	}
+	request, err := driverprotocol.Parse(os.Args[1:])
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(90)
+	}
+	if os.Getenv("FAKE_DRIVER_EXPECT_NO_PACK") != "" && request.Project.Pack != nil {
+		os.Exit(94)
+	}
+	switch request.Action {
+	case driverprotocol.ActionRun:
+		fmt.Printf("run-args=%s\n", strings.Join(request.ApplicationArgs, "|"))
+	case driverprotocol.ActionBuild:
+		if request.Output == nil {
+			os.Exit(91)
+		}
+		self, err := os.Executable()
+		if err != nil { panic(err) }
+		data, err := os.ReadFile(self)
+		if err != nil { panic(err) }
+		if err := os.WriteFile(request.Output.Staging, data, 0755); err != nil { panic(err) }
+		if runtime.GOOS == "darwin" {
+			if data, err := exec.Command("/usr/bin/codesign", "--force", "--sign", "-", request.Output.Staging).CombinedOutput(); err != nil {
+				fmt.Fprintln(os.Stderr, string(data))
+				os.Exit(93)
+			}
+		}
+	default:
+		os.Exit(92)
+	}
+}
+`
+
+func cliCommand(xgo, xgoRoot, dir string, args ...string) *exec.Cmd {
+	cmd := exec.Command(xgo, args...)
+	cmd.Dir = dir
+	cmd.Env = append(os.Environ(), "GOWORK=off", "XGOROOT="+xgoRoot)
+	return cmd
+}
+
+func assertNoAutogen(t *testing.T, dir string) {
+	t.Helper()
+	if _, err := os.Stat(filepath.Join(dir, "xgo_autogen.go")); !os.IsNotExist(err) {
+		t.Fatalf("driver path touched xgo_autogen.go: %v", err)
+	}
+}

--- a/cmd/internal/projectdriver/command_test.go
+++ b/cmd/internal/projectdriver/command_test.go
@@ -1,0 +1,54 @@
+/*
+ * Copyright (c) 2026 The XGo Authors (xgo.dev). All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package projectdriver
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"strings"
+	"testing"
+)
+
+func TestRunCapturedCommand(t *testing.T) {
+	if os.Getenv("XGO_TEST_CAPTURED_COMMAND") == "1" {
+		fmt.Fprint(os.Stdout, "captured stdout")
+		fmt.Fprintln(os.Stderr, "captured stderr")
+		os.Exit(17)
+	}
+	cmd := exec.Command(os.Args[0], "-test.run=^TestRunCapturedCommand$")
+	cmd.Env = append(os.Environ(), "XGO_TEST_CAPTURED_COMMAND=1")
+	stdout, stderr, err := runCapturedCommand(cmd, "test command")
+	if string(stdout) != "captured stdout" || string(stderr) != "captured stderr\n" {
+		t.Fatalf("captured output = %q, %q", stdout, stderr)
+	}
+	if err == nil || !strings.Contains(err.Error(), "test command: exit status 17: captured stderr") {
+		t.Fatalf("captured error = %v", err)
+	}
+}
+
+func TestCommandErrorWithoutStderr(t *testing.T) {
+	cause := errors.New("failed")
+	err := commandError("test command", cause, " \n\t")
+	if got, want := err.Error(), "test command: failed"; got != want {
+		t.Fatalf("command error = %q, want %q", got, want)
+	}
+	if !errors.Is(err, cause) {
+		t.Fatalf("command error does not wrap cause: %v", err)
+	}
+}

--- a/cmd/internal/projectdriver/dispatch.go
+++ b/cmd/internal/projectdriver/dispatch.go
@@ -1,0 +1,145 @@
+/*
+ * Copyright (c) 2026 The XGo Authors (xgo.dev). All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package projectdriver
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+
+	"github.com/goplus/xgo/x/xgoprojs"
+)
+
+// DispatchResult reports whether a driver-backed target was selected and, if so,
+// the driver process status and build output path.
+type DispatchResult struct {
+	Handled bool
+	Status  ProcessStatus
+	Output  string
+}
+
+// TryRun resolves and, when matched, runs one driver-backed target. It never exits
+// the process; command entry points own status-to-exit translation.
+func TryRun(ctx context.Context, cwd string, target xgoprojs.Proj, flags, appArgs []string, streams Streams) (DispatchResult, error) {
+	// Consume only XGo's application separator; protocol encoding adds its own
+	// wire delimiter and preserves every subsequent argument.
+	if len(appArgs) != 0 && appArgs[0] == "--" {
+		appArgs = appArgs[1:]
+	}
+	return dispatchOne(ctx, cwd, target, flags, actionRun, func(ctx context.Context, resolver *Resolver, drv *Driver) (ProcessStatus, string, error) {
+		status, err := resolver.Run(ctx, drv, appArgs, streams)
+		return status, "", err
+	})
+}
+
+// TryBuild resolves and, when matched, builds one driver-backed target. It never
+// exits the process; command entry points own status-to-exit translation.
+func TryBuild(ctx context.Context, cwd string, target xgoprojs.Proj, flags []string, output string, streams Streams) (DispatchResult, error) {
+	return dispatchOne(ctx, cwd, target, flags, actionBuild, func(ctx context.Context, resolver *Resolver, drv *Driver) (ProcessStatus, string, error) {
+		return resolver.Build(ctx, drv, output, streams)
+	})
+}
+
+// TryInstall resolves all targets before creating output or starting a driver.
+func TryInstall(ctx context.Context, cwd string, targets []xgoprojs.Proj, flags []string, streams Streams) (DispatchResult, error) {
+	if len(targets) == 0 {
+		return DispatchResult{}, fmt.Errorf("driver install requires at least one target")
+	}
+	for _, target := range targets {
+		if target == nil {
+			return DispatchResult{}, fmt.Errorf("driver install requires non-nil targets")
+		}
+	}
+	resolver, ctx, err := newDispatchResolver(ctx, cwd, flags)
+	if err != nil {
+		return DispatchResult{}, err
+	}
+	drivers := make([]*Driver, 0, len(targets))
+	for _, target := range targets {
+		drv, handled, err := resolveTarget(ctx, resolver, target)
+		if err != nil {
+			return DispatchResult{}, err
+		}
+		if handled {
+			drivers = append(drivers, drv)
+		}
+	}
+	if len(drivers) == 0 {
+		return DispatchResult{}, nil
+	}
+	if len(targets) != 1 {
+		return DispatchResult{}, fmt.Errorf("driver v1 install accepts exactly one target")
+	}
+	boundary := beginDriverSignalBoundary(ctx)
+	status, final, err := resolver.Install(boundary.Context(), drivers[0], streams)
+	return finishDispatch(boundary, status, final, err)
+}
+
+func dispatchOne(ctx context.Context, cwd string, target xgoprojs.Proj, flags []string, act action, run func(context.Context, *Resolver, *Driver) (ProcessStatus, string, error)) (DispatchResult, error) {
+	if target == nil {
+		return DispatchResult{}, fmt.Errorf("driver %s requires a non-nil target", act)
+	}
+	resolver, ctx, err := newDispatchResolver(ctx, cwd, flags)
+	if err != nil {
+		return DispatchResult{}, err
+	}
+	drv, handled, err := resolveTarget(ctx, resolver, target)
+	if err != nil || !handled {
+		return DispatchResult{Handled: handled}, err
+	}
+	boundary := beginDriverSignalBoundary(ctx)
+	status, output, err := run(boundary.Context(), resolver, drv)
+	return finishDispatch(boundary, status, output, err)
+}
+
+func finishDispatch(boundary *driverSignalBoundary, status ProcessStatus, output string, err error) (DispatchResult, error) {
+	status, err = boundary.Finish(status, err)
+	if err != nil {
+		return DispatchResult{}, err
+	}
+	return DispatchResult{Handled: true, Status: status, Output: output}, nil
+}
+
+func newDispatchResolver(ctx context.Context, cwd string, flags []string) (*Resolver, context.Context, error) {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	var err error
+	if cwd == "" {
+		cwd, err = os.Getwd()
+		if err != nil {
+			return nil, ctx, err
+		}
+	}
+	resolver, err := NewResolver(ctx, cwd, flags)
+	if err != nil {
+		return nil, ctx, err
+	}
+	return resolver, ctx, nil
+}
+
+func resolveTarget(ctx context.Context, resolver *Resolver, target xgoprojs.Proj) (*Driver, bool, error) {
+	drv, err := resolver.Resolve(ctx, target)
+	if errors.Is(err, ErrNotHandled) {
+		return nil, false, nil
+	}
+	if err != nil {
+		return nil, false, err
+	}
+	return drv, true, nil
+}

--- a/cmd/internal/projectdriver/dispatch_test.go
+++ b/cmd/internal/projectdriver/dispatch_test.go
@@ -1,0 +1,189 @@
+/*
+ * Copyright (c) 2026 The XGo Authors (xgo.dev). All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package projectdriver
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/goplus/xgo/x/xgoprojs"
+)
+
+func TestTryDispatchRequiresTargets(t *testing.T) {
+	if _, err := TryRun(context.Background(), "", nil, nil, nil, Streams{}); err == nil {
+		t.Fatal("TryRun accepted a nil target")
+	}
+	if _, err := TryBuild(context.Background(), "", nil, nil, "", Streams{}); err == nil {
+		t.Fatal("TryBuild accepted a nil target")
+	}
+	if _, err := TryInstall(context.Background(), "", nil, nil, Streams{}); err == nil {
+		t.Fatal("TryInstall accepted zero targets")
+	}
+	if _, err := TryInstall(context.Background(), "", []xgoprojs.Proj{nil}, nil, Streams{}); err == nil {
+		t.Fatal("TryInstall accepted a nil target entry")
+	}
+}
+
+func TestTryBuildKeepWorkAllowsNilStderr(t *testing.T) {
+	if testing.Short() {
+		t.Skip("invokes the host Go command")
+	}
+	fixture := newDriverFixture(t)
+	useDriverCapableXGo(t)
+	output := filepath.Join(fixture.root, "game")
+	var stdout bytes.Buffer
+	result, err := TryBuild(context.Background(), fixture.app, &xgoprojs.DirProj{Dir: fixture.project}, []string{"-work=true"}, output, Streams{Stdout: &stdout})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !result.Handled || result.Status.Code != 0 || result.Output != output {
+		t.Fatalf("build = %#v", result)
+	}
+	if info, err := os.Stat(output); err != nil || info.Size() == 0 {
+		t.Fatalf("build output = %#v, %v", info, err)
+	}
+}
+
+func TestTryRunConsumesApplicationDelimiter(t *testing.T) {
+	if testing.Short() {
+		t.Skip("invokes the host Go command")
+	}
+	fixture := newDriverFixture(t)
+	useDriverCapableXGo(t)
+	var stdout bytes.Buffer
+	result, err := TryRun(
+		context.Background(),
+		fixture.app,
+		&xgoprojs.DirProj{Dir: fixture.project},
+		nil,
+		[]string{"--", "argument", "--"},
+		Streams{Stdout: &stdout},
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !result.Handled || result.Status.Code != 0 {
+		t.Fatalf("run = %#v", result)
+	}
+	if got := strings.TrimSpace(stdout.String()); got != "run-args=argument|--" {
+		t.Fatalf("application args = %q", got)
+	}
+}
+
+func TestDispatchRejectsMixedTargetsBeforeDriver(t *testing.T) {
+	if testing.Short() {
+		t.Skip("invokes the host Go command")
+	}
+	fixture := newDriverFixture(t)
+	useDriverCapableXGo(t)
+	plain := filepath.Join(fixture.app, "plain")
+	mustMkdirAll(t, plain)
+	mustWriteFile(t, filepath.Join(plain, "main.go"), "package main\nfunc main() {}\n")
+	marker := filepath.Join(fixture.root, "driver-started")
+	t.Setenv("FAKE_DRIVER_MARKER", marker)
+	result, err := TryInstall(context.Background(), "", []xgoprojs.Proj{&xgoprojs.DirProj{Dir: plain}, &xgoprojs.DirProj{Dir: fixture.project}}, nil, Streams{})
+	if err == nil || !strings.Contains(err.Error(), "exactly one target") {
+		t.Fatalf("dispatch = %#v, %v", result, err)
+	}
+	if result.Handled {
+		t.Fatalf("mixed dispatch was handled: %#v", result)
+	}
+	if _, err := os.Stat(marker); !os.IsNotExist(err) {
+		t.Fatalf("driver started before target validation: %v", err)
+	}
+}
+
+func TestDispatchDeferredPolicyLegacyFallback(t *testing.T) {
+	if testing.Short() {
+		t.Skip("invokes the host Go command")
+	}
+	dir := t.TempDir()
+	mustWriteFile(t, filepath.Join(dir, "go.mod"), "module example.test/plain\n\ngo 1.25\n")
+	mustWriteFile(t, filepath.Join(dir, "main.go"), "package main\nfunc main() {}\n")
+	t.Setenv("GOENV", "off")
+	t.Setenv("GOFLAGS", "")
+	t.Setenv("GOWORK", "off")
+	target := &xgoprojs.DirProj{Dir: dir}
+	for _, action := range []string{"run", "build", "install"} {
+		t.Run(action, func(t *testing.T) {
+			var result DispatchResult
+			var err error
+			switch action {
+			case "run":
+				result, err = TryRun(context.Background(), dir, target, []string{"-x=invalid"}, nil, Streams{})
+			case "build":
+				result, err = TryBuild(context.Background(), dir, target, []string{"-x=invalid"}, filepath.Join(dir, "plain"), Streams{})
+			case "install":
+				result, err = TryInstall(context.Background(), dir, []xgoprojs.Proj{target}, []string{"-x=invalid"}, Streams{})
+			}
+			if err != nil || result.Handled {
+				t.Fatalf("%s = %#v, %v; want legacy fallback", action, result, err)
+			}
+		})
+	}
+}
+
+func TestDispatchRejectsDeferredPolicyBeforeDriverActions(t *testing.T) {
+	if testing.Short() {
+		t.Skip("invokes the host Go command")
+	}
+	useDriverCapableXGo(t)
+	for _, action := range []string{"run", "build", "install"} {
+		for _, source := range []string{"cli", "ambient"} {
+			t.Run(action+"/"+source, func(t *testing.T) {
+				fixture := newDriverFixture(t)
+				t.Setenv("GOENV", "off")
+				marker := filepath.Join(fixture.root, "driver-started")
+				t.Setenv("FAKE_DRIVER_MARKER", marker)
+				badFlag := "-x=invalid"
+				var flags []string
+				if source == "ambient" {
+					t.Setenv("GOFLAGS", badFlag)
+				} else {
+					t.Setenv("GOFLAGS", "")
+					flags = []string{badFlag}
+				}
+				target := &xgoprojs.DirProj{Dir: fixture.project}
+				output := filepath.Join(fixture.root, "must-not-exist", "game")
+				var err error
+				switch action {
+				case "run":
+					_, err = TryRun(context.Background(), fixture.app, target, flags, nil, Streams{})
+				case "build":
+					_, err = TryBuild(context.Background(), fixture.app, target, flags, output, Streams{})
+				case "install":
+					t.Setenv("GOBIN", filepath.Dir(output))
+					_, err = TryInstall(context.Background(), fixture.app, []xgoprojs.Proj{target}, flags, Streams{})
+				}
+				if err == nil || !strings.Contains(err.Error(), badFlag) {
+					t.Fatalf("%s error = %v, want rejection of %q", action, err, badFlag)
+				}
+				if _, statErr := os.Stat(marker); !errors.Is(statErr, os.ErrNotExist) {
+					t.Fatalf("driver started before rejection: %v", statErr)
+				}
+				if _, statErr := os.Stat(filepath.Dir(output)); !errors.Is(statErr, os.ErrNotExist) {
+					t.Fatalf("output created before rejection: %v", statErr)
+				}
+			})
+		}
+	}
+}

--- a/cmd/internal/projectdriver/driver.go
+++ b/cmd/internal/projectdriver/driver.go
@@ -1,0 +1,255 @@
+/*
+ * Copyright (c) 2026 The XGo Authors (xgo.dev). All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package projectdriver
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+)
+
+type builtDriver struct {
+	path string
+	dir  string
+	keep bool
+}
+
+func (r *Resolver) Run(ctx context.Context, drv *Driver, appArgs []string, streams Streams) (ProcessStatus, error) {
+	return execute(ctx, drv, actionRun, "", "", appArgs, fillStreams(streams))
+}
+
+func (r *Resolver) Build(ctx context.Context, drv *Driver, requestedOutput string, streams Streams) (ProcessStatus, string, error) {
+	return r.buildTo(ctx, drv, requestedOutput, streams)
+}
+
+func (r *Resolver) buildTo(ctx context.Context, drv *Driver, requestedOutput string, streams Streams) (ProcessStatus, string, error) {
+	policy := drv.buildPolicy
+	streams = fillStreams(streams)
+	final, err := resolveBuildOutput(r.cwd, requestedOutput, drv.DefaultExecName)
+	if err != nil {
+		return ProcessStatus{}, "", err
+	}
+	tx, err := beginOutputTransaction(final, policy.KeepWork)
+	if err != nil {
+		return ProcessStatus{}, final, err
+	}
+	defer tx.abort()
+	if policy.KeepWork {
+		fmt.Fprintf(streams.Stderr, "XGO_DRIVER_OUTPUT_WORK=%s\n", tx.dir)
+	}
+	status, err := execute(ctx, drv, actionBuild, tx.staged, final, nil, streams)
+	if err != nil || !status.Success() {
+		return status, final, err
+	}
+	if err := tx.commitContext(ctx); err != nil {
+		return ProcessStatus{}, final, err
+	}
+	return successStatus(), final, nil
+}
+
+// Install builds one driver-backed target transactionally into the effective GOBIN.
+func (r *Resolver) Install(ctx context.Context, drv *Driver, streams Streams) (ProcessStatus, string, error) {
+	bin, err := installBin(ctx, drv.Graph)
+	if err != nil {
+		return ProcessStatus{}, "", err
+	}
+	return r.buildTo(ctx, drv, filepath.Join(bin, executableName(drv.DefaultExecName)), streams)
+}
+
+func installBin(ctx context.Context, graph GraphPolicy) (string, error) {
+	cmd := graphCommand(ctx, graph, graph.WorkDir, "env", "-json", "GOBIN", "GOPATH")
+	stdout, _, err := runCapturedCommand(cmd, "resolve install directory")
+	if err != nil {
+		return "", err
+	}
+	values := make(map[string]string)
+	if err := json.Unmarshal(stdout, &values); err != nil {
+		return "", fmt.Errorf("decode Go install directory: %w", err)
+	}
+	bin := values["GOBIN"]
+	if bin == "" {
+		paths := filepath.SplitList(values["GOPATH"])
+		if len(paths) == 0 || paths[0] == "" {
+			return "", fmt.Errorf("go env GOPATH is empty")
+		}
+		bin = filepath.Join(paths[0], "bin")
+	}
+	if !filepath.IsAbs(bin) {
+		return "", fmt.Errorf("Go install directory %q is not absolute", bin)
+	}
+	return filepath.Clean(bin), nil
+}
+
+func execute(ctx context.Context, drv *Driver, act action, output, finalOutput string, appArgs []string, streams Streams) (ProcessStatus, error) {
+	policy := drv.buildPolicy
+	driver, err := buildDriver(ctx, drv, policy, streams)
+	if err != nil {
+		return ProcessStatus{}, err
+	}
+	defer driver.cleanup()
+	args, err := driverArgs(drv, act, policy, output, finalOutput, appArgs)
+	if err != nil {
+		return ProcessStatus{}, err
+	}
+	env := driverEnvironment(os.Environ(), drv)
+	if err := validateArgv(driver.path, args, env); err != nil {
+		return ProcessStatus{}, err
+	}
+	if policy.Trace {
+		fmt.Fprintln(streams.Stderr, formatCommandForTrace(driver.path, args))
+	}
+	if err := verifyTargetModFile(drv.TargetModFile); err != nil {
+		return ProcessStatus{}, err
+	}
+	cmd := exec.Command(driver.path, args...)
+	cmd.Dir = drv.ProjectDir
+	cmd.Env = env
+	cmd.Stdin, cmd.Stdout, cmd.Stderr = streams.Stdin, streams.Stdout, streams.Stderr
+	return runDriverProcess(ctx, cmd)
+}
+
+func buildDriver(ctx context.Context, drv *Driver, policy BuildPolicy, streams Streams) (*builtDriver, error) {
+	if goos := os.Getenv("GOOS"); goos != "" && goos != runtime.GOOS {
+		return nil, fmt.Errorf("drivers are host-only: GOOS=%s, host=%s", goos, runtime.GOOS)
+	}
+	if goarch := os.Getenv("GOARCH"); goarch != "" && goarch != runtime.GOARCH {
+		return nil, fmt.Errorf("drivers are host-only: GOARCH=%s, host=%s", goarch, runtime.GOARCH)
+	}
+	if err := verifyTargetModFile(drv.TargetModFile); err != nil {
+		return nil, err
+	}
+	if err := validateDriver(ctx, drv); err != nil {
+		return nil, err
+	}
+	if err := verifyTargetModFile(drv.TargetModFile); err != nil {
+		return nil, err
+	}
+	dir, err := os.MkdirTemp("", "xgo-driver-")
+	if err != nil {
+		return nil, err
+	}
+	driver := &builtDriver{dir: dir, path: filepath.Join(dir, executableName("driver")), keep: policy.KeepWork}
+	if policy.KeepWork {
+		fmt.Fprintf(streams.Stderr, "XGO_DRIVER_WORK=%s\n", dir)
+	}
+	args := drv.Graph.goArgs("build")
+	args = append(args, policy.goBuildFlags()...)
+	args = append(args, "-buildmode=exe", "-o", driver.path, drv.DriverPackage)
+	cmd := exec.CommandContext(ctx, drv.Graph.GoCommand, args...)
+	cmd.Dir = drv.Graph.WorkDir
+	cmd.Env = hostBuildEnvironment(os.Environ(), drv.Graph.GoWork)
+	cmd.Stdin, cmd.Stdout, cmd.Stderr = streams.Stdin, streams.Stdout, streams.Stderr
+	if policy.Trace {
+		fmt.Fprintln(streams.Stderr, formatCommandForTrace(drv.Graph.GoCommand, args))
+	}
+	if err := cmd.Run(); err != nil {
+		driver.cleanup()
+		return nil, fmt.Errorf("build driver %q: %w", drv.DriverPackage, err)
+	}
+	info, err := os.Lstat(driver.path)
+	if err != nil {
+		driver.cleanup()
+		return nil, fmt.Errorf("driver build output: %w", err)
+	}
+	if info.Mode()&os.ModeSymlink != 0 || !info.Mode().IsRegular() || info.Size() == 0 {
+		driver.cleanup()
+		return nil, fmt.Errorf("driver build did not produce a regular executable")
+	}
+	if err := verifyTargetModFile(drv.TargetModFile); err != nil {
+		driver.cleanup()
+		return nil, err
+	}
+	return driver, nil
+}
+
+func (p *builtDriver) cleanup() {
+	if p != nil && !p.keep {
+		_ = os.RemoveAll(p.dir)
+	}
+}
+
+func validateDriver(ctx context.Context, drv *Driver) error {
+	if !moduleContainsPackage(drv.Origin.Selected.Path, drv.DriverPackage) {
+		return fmt.Errorf("driver package %q is outside declaring module %q", drv.DriverPackage, drv.Origin.Selected.Path)
+	}
+	args := drv.Graph.goArgs("list", "-json", drv.DriverPackage)
+	cmd := graphCommand(ctx, drv.Graph, drv.Graph.WorkDir, args...)
+	stdout, _, err := runCapturedCommand(cmd, "validate driver")
+	if err != nil {
+		return err
+	}
+	var pkg goListPackage
+	if err := json.Unmarshal(stdout, &pkg); err != nil {
+		return fmt.Errorf("decode driver package: %w", err)
+	}
+	if pkg.Error != nil && pkg.Error.Err != "" {
+		return fmt.Errorf("driver package: %s", pkg.Error.Err)
+	}
+	if pkg.ImportPath != drv.DriverPackage {
+		return fmt.Errorf("driver resolved as %q, want %q", pkg.ImportPath, drv.DriverPackage)
+	}
+	if pkg.Name != "main" {
+		return fmt.Errorf("driver package %q is %q, want command package main", drv.DriverPackage, pkg.Name)
+	}
+	if pkg.Module == nil {
+		return fmt.Errorf("driver package %q has no module provenance", drv.DriverPackage)
+	}
+	module, err := normalizeListedModule(*pkg.Module)
+	if err != nil {
+		return err
+	}
+	if !module.Equal(drv.Origin) {
+		return fmt.Errorf("driver package %q does not match declaring module provenance", drv.DriverPackage)
+	}
+	driverDir, err := canonicalExistingDir(pkg.Dir)
+	if err != nil {
+		return fmt.Errorf("driver directory: %w", err)
+	}
+	if !pathWithin(drv.Origin.Effective().Dir, driverDir) {
+		return fmt.Errorf("driver directory escapes declaring module")
+	}
+	return nil
+}
+
+func hostBuildEnvironment(base []string, goWork string) []string {
+	env := graphEnvironment(base, goWork)
+	env = replaceEnv(env, "GOOS", runtime.GOOS)
+	env = replaceEnv(env, "GOARCH", runtime.GOARCH)
+	return env
+}
+
+func driverEnvironment(base []string, drv *Driver) []string {
+	env := hostBuildEnvironment(base, drv.Graph.GoWork)
+	return replaceEnv(env, driverGuardEnv, "1")
+}
+
+func fillStreams(streams Streams) Streams {
+	if streams.Stdin == nil {
+		streams.Stdin = os.Stdin
+	}
+	if streams.Stdout == nil {
+		streams.Stdout = os.Stdout
+	}
+	if streams.Stderr == nil {
+		streams.Stderr = os.Stderr
+	}
+	return streams
+}

--- a/cmd/internal/projectdriver/driver_test.go
+++ b/cmd/internal/projectdriver/driver_test.go
@@ -1,0 +1,340 @@
+/*
+ * Copyright (c) 2026 The XGo Authors (xgo.dev). All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package projectdriver
+
+import (
+	"bytes"
+	"context"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/goplus/xgo/x/xgoprojs"
+)
+
+func TestDriverRunAndBuild(t *testing.T) {
+	if testing.Short() {
+		t.Skip("invokes the host Go command")
+	}
+	fixture := newDriverFixture(t)
+	resolver := fixture.resolver(t, "-trimpath=true", "-buildvcs=false")
+	drv := resolveDriver(t, resolver, &xgoprojs.DirProj{Dir: fixture.project})
+	wantPolicy := BuildPolicy{TrimPath: true, DisableBuildVCS: true}
+	if drv.buildPolicy != wantPolicy {
+		t.Fatalf("build policy = %#v, want %#v", drv.buildPolicy, wantPolicy)
+	}
+	var stdout, stderr bytes.Buffer
+	status, err := resolver.Run(context.Background(), drv, []string{"", "a b", "--"}, Streams{Stdout: &stdout, Stderr: &stderr})
+	if err != nil || status.Code != 0 || status.Signaled {
+		t.Fatalf("run = %#v, %v, stderr=%s", status, err, &stderr)
+	}
+	if got := strings.TrimSpace(stdout.String()); got != "run-args=|a b|--" {
+		t.Fatalf("stdout = %q", got)
+	}
+
+	final := filepath.Join(fixture.root, "bin", "game")
+	if runtime.GOOS == "windows" {
+		final += ".exe"
+	}
+	if err := os.MkdirAll(filepath.Dir(final), 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(final, []byte("old"), 0755); err != nil {
+		t.Fatal(err)
+	}
+	status, gotFinal, err := resolver.Build(context.Background(), drv, final, Streams{Stdout: &stdout, Stderr: &stderr})
+	if err != nil || status.Code != 0 || gotFinal != final {
+		t.Fatalf("build = %#v, %q, %v, stderr=%s", status, gotFinal, err, &stderr)
+	}
+	info, err := os.Stat(final)
+	if err != nil || info.Size() <= int64(len("old")) {
+		t.Fatalf("artifact = %#v, %v", info, err)
+	}
+}
+
+func TestDriverRejectsChangedTargetModFile(t *testing.T) {
+	if testing.Short() {
+		t.Skip("invokes the host Go command")
+	}
+	fixture := newDriverFixture(t)
+	resolver := fixture.resolver(t)
+	drv := resolveDriver(t, resolver, &xgoprojs.DirProj{Dir: fixture.project})
+	goMod := filepath.Join(fixture.app, "go.mod")
+	data, err := os.ReadFile(goMod)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(goMod, append(data, '\n'), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	marker := filepath.Join(fixture.root, "driver-started")
+	t.Setenv("FAKE_DRIVER_MARKER", marker)
+	if _, err := resolver.Run(context.Background(), drv, nil, Streams{}); err == nil || !strings.Contains(err.Error(), "target modfile") {
+		t.Fatalf("Run() error = %v, want target modfile change", err)
+	}
+	if _, err := os.Stat(marker); !os.IsNotExist(err) {
+		t.Fatalf("driver started after target modfile change: %v", err)
+	}
+}
+
+func TestDriverRejectsTargetModFileChangedByBuild(t *testing.T) {
+	if testing.Short() || runtime.GOOS == "windows" {
+		t.Skip("uses a host shell wrapper around the Go command")
+	}
+	fixture := newDriverFixture(t)
+	resolver := fixture.resolver(t)
+	drv := resolveDriver(t, resolver, &xgoprojs.DirProj{Dir: fixture.project})
+	wrapper := filepath.Join(fixture.root, "go-wrapper")
+	mustWriteFile(t, wrapper, `#!/bin/sh
+"$REAL_GO" "$@"
+status=$?
+for arg do
+	if [ "$arg" = build ]; then
+		printf '\n' >> "$TARGET_MODFILE"
+	fi
+done
+exit "$status"
+`)
+	if err := os.Chmod(wrapper, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("REAL_GO", drv.Graph.GoCommand)
+	t.Setenv("TARGET_MODFILE", drv.TargetModFile.Path)
+	drv.Graph.GoCommand = wrapper
+	marker := filepath.Join(fixture.root, "driver-started")
+	t.Setenv("FAKE_DRIVER_MARKER", marker)
+	if _, err := resolver.Run(context.Background(), drv, nil, Streams{}); err == nil || !strings.Contains(err.Error(), "target modfile") {
+		t.Fatalf("Run() error = %v, want post-build target modfile change", err)
+	}
+	if _, err := os.Stat(marker); !os.IsNotExist(err) {
+		t.Fatalf("driver started after build changed target modfile: %v", err)
+	}
+}
+
+func TestDriverBuildFailurePreservesOutput(t *testing.T) {
+	if testing.Short() {
+		t.Skip("invokes the host Go command")
+	}
+	fixture := newDriverFixture(t)
+	resolver := fixture.resolver(t)
+	drv := resolveDriver(t, resolver, &xgoprojs.DirProj{Dir: fixture.project})
+	final := filepath.Join(fixture.root, "game")
+	if runtime.GOOS == "windows" {
+		final += ".exe"
+	}
+	if err := os.WriteFile(final, []byte("old"), 0755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("FAKE_DRIVER_EXIT", "42")
+	status, _, err := resolver.Build(context.Background(), drv, final, Streams{Stdout: new(bytes.Buffer), Stderr: new(bytes.Buffer)})
+	if err != nil || status.Code != 42 {
+		t.Fatalf("build failure = %#v, %v", status, err)
+	}
+	data, readErr := os.ReadFile(final)
+	if readErr != nil || string(data) != "old" {
+		t.Fatalf("old output changed: %q, %v", data, readErr)
+	}
+	assertNoOutputWorkDirs(t, filepath.Dir(final))
+}
+
+func TestDriverKeepWorkIsReportedBeforeExecution(t *testing.T) {
+	if testing.Short() {
+		t.Skip("invokes the host Go command")
+	}
+	fixture := newDriverFixture(t)
+	resolver := fixture.resolver(t)
+	drv := resolveDriver(t, resolver, &xgoprojs.DirProj{Dir: fixture.project})
+	drv.buildPolicy.KeepWork = true
+	t.Setenv("FAKE_DRIVER_BLOCK", "1")
+
+	var stderr synchronizedBuffer
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	done := make(chan struct{})
+	output := filepath.Join(fixture.root, "bin", executableName("game"))
+	go func() {
+		defer close(done)
+		_, _, _ = resolver.Build(ctx, drv, output, Streams{Stderr: &stderr})
+	}()
+
+	paths := make(map[string]string)
+	deadline := time.NewTimer(15 * time.Second)
+	defer deadline.Stop()
+	for len(paths) != 2 {
+		for _, key := range []string{"XGO_DRIVER_OUTPUT_WORK", "XGO_DRIVER_WORK"} {
+			if path := reportedPath(stderr.String(), key); path != "" {
+				paths[key] = path
+			}
+		}
+		select {
+		case <-done:
+			t.Fatalf("build completed before reporting -work paths:\n%s", stderr.String())
+		case <-deadline.C:
+			cancel()
+			<-done
+			t.Fatalf("-work paths were not reported before execution completed:\n%s", stderr.String())
+		case <-time.After(10 * time.Millisecond):
+		}
+	}
+	for key, path := range paths {
+		if info, err := os.Stat(path); err != nil || !info.IsDir() {
+			t.Fatalf("%s = %q: %#v, %v", key, path, info, err)
+		}
+		path := path
+		t.Cleanup(func() { _ = os.RemoveAll(path) })
+	}
+	cancel()
+	select {
+	case <-done:
+	case <-time.After(15 * time.Second):
+		t.Fatal("canceled driver did not exit")
+	}
+}
+
+type synchronizedBuffer struct {
+	mu     sync.Mutex
+	buffer bytes.Buffer
+}
+
+func (b *synchronizedBuffer) Write(data []byte) (int, error) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.buffer.Write(data)
+}
+
+func (b *synchronizedBuffer) String() string {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.buffer.String()
+}
+
+func reportedPath(output, key string) string {
+	prefix := key + "="
+	for _, line := range strings.Split(output, "\n") {
+		if strings.HasPrefix(line, prefix) {
+			return strings.TrimPrefix(line, prefix)
+		}
+	}
+	return ""
+}
+
+func TestDriverBuildCancellationPreservesOutput(t *testing.T) {
+	if testing.Short() {
+		t.Skip("invokes the host Go command")
+	}
+	fixture := newDriverFixture(t)
+	resolver := fixture.resolver(t)
+	drv := resolveDriver(t, resolver, &xgoprojs.DirProj{Dir: fixture.project})
+	final := filepath.Join(fixture.root, "game")
+	if runtime.GOOS == "windows" {
+		final += ".exe"
+	}
+	if err := os.WriteFile(final, []byte("old"), 0755); err != nil {
+		t.Fatal(err)
+	}
+	marker := filepath.Join(fixture.root, "driver-started")
+	t.Setenv("FAKE_DRIVER_MARKER", marker)
+	t.Setenv("FAKE_DRIVER_BLOCK", "1")
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		_, _, _ = resolver.Build(ctx, drv, final, Streams{Stdout: new(bytes.Buffer), Stderr: new(bytes.Buffer)})
+	}()
+	deadline := time.Now().Add(15 * time.Second)
+	for {
+		if _, err := os.Stat(marker); err == nil {
+			break
+		}
+		if time.Now().After(deadline) {
+			cancel()
+			<-done
+			t.Fatal("driver did not start")
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	cancel()
+	select {
+	case <-done:
+	case <-time.After(15 * time.Second):
+		t.Fatal("canceled driver did not exit")
+	}
+	data, readErr := os.ReadFile(final)
+	if readErr != nil || string(data) != "old" {
+		t.Fatalf("canceled build changed old output: %q, %v", data, readErr)
+	}
+	assertNoOutputWorkDirs(t, filepath.Dir(final))
+}
+
+func assertNoOutputWorkDirs(t *testing.T, parent string) {
+	t.Helper()
+	matches, err := filepath.Glob(filepath.Join(parent, ".xgo-driver-output-*"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(matches) != 0 {
+		t.Fatalf("driver output work directories remain: %v", matches)
+	}
+}
+
+func TestDriverInstallUsesEffectiveGOBIN(t *testing.T) {
+	if testing.Short() {
+		t.Skip("invokes the host Go command")
+	}
+	fixture := newDriverFixture(t)
+	resolver := fixture.resolver(t)
+	drv := resolveDriver(t, resolver, &xgoprojs.DirProj{Dir: fixture.project})
+	bin := filepath.Join(fixture.root, "custom-bin")
+	t.Setenv("GOBIN", bin)
+	status, final, err := resolver.Install(context.Background(), drv, Streams{Stdout: new(bytes.Buffer), Stderr: new(bytes.Buffer)})
+	if err != nil || status.Code != 0 {
+		t.Fatalf("install = %#v, %q, %v", status, final, err)
+	}
+	want := filepath.Join(bin, executableName("game"))
+	if final != want {
+		t.Fatalf("install output = %q, want %q", final, want)
+	}
+	if info, err := os.Stat(final); err != nil || info.Size() == 0 {
+		t.Fatalf("installed artifact = %#v, %v", info, err)
+	}
+}
+
+func TestHostBuildEnvironmentPreservesCGO(t *testing.T) {
+	env := hostBuildEnvironment([]string{
+		"GOOS=target-os",
+		"GOARCH=target-arch",
+		"CGO_ENABLED=1",
+	}, "off")
+	if got, _ := environmentValue(env, "GOOS"); got != runtime.GOOS {
+		t.Fatalf("GOOS = %q, want host %q", got, runtime.GOOS)
+	}
+	if got, _ := environmentValue(env, "GOARCH"); got != runtime.GOARCH {
+		t.Fatalf("GOARCH = %q, want host %q", got, runtime.GOARCH)
+	}
+	if got, ok := environmentValue(env, "CGO_ENABLED"); !ok || got != "1" {
+		t.Fatalf("CGO_ENABLED = %q, %t; want inherited value 1", got, ok)
+	}
+
+	env = hostBuildEnvironment([]string{"PATH=/bin"}, "off")
+	if got, ok := environmentValue(env, "CGO_ENABLED"); ok {
+		t.Fatalf("CGO_ENABLED = %q; host default should remain unset", got)
+	}
+}

--- a/cmd/internal/projectdriver/executable_darwin.go
+++ b/cmd/internal/projectdriver/executable_darwin.go
@@ -1,0 +1,104 @@
+//go:build darwin
+
+/*
+ * Copyright (c) 2026 The XGo Authors (xgo.dev). All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package projectdriver
+
+import (
+	"bytes"
+	"debug/macho"
+	"fmt"
+	"os"
+	"os/exec"
+	"runtime"
+	"strings"
+	"unsafe"
+
+	"golang.org/x/sys/unix"
+)
+
+func validateHostExecutable(input *os.File, path string) error {
+	if err := validateMachOExecutable(input); err != nil {
+		return fmt.Errorf("driver output is not a Darwin executable: %w", err)
+	}
+	currentPath, err := openFilePath(input)
+	if err != nil {
+		return fmt.Errorf("resolve driver output %q: %w", path, err)
+	}
+	identity, err := input.Stat()
+	if err != nil {
+		return err
+	}
+	if info, err := os.Lstat(currentPath); err != nil || !os.SameFile(identity, info) {
+		return fmt.Errorf("driver output changed before signature validation")
+	}
+	cmd := exec.Command("/usr/bin/codesign", "--verify", "--strict", currentPath)
+	if output, err := cmd.CombinedOutput(); err != nil {
+		return fmt.Errorf("driver output has no valid Darwin signature: %w: %s", err, strings.TrimSpace(string(output)))
+	}
+	if info, err := os.Lstat(currentPath); err != nil || !os.SameFile(identity, info) {
+		return fmt.Errorf("driver output changed during signature validation")
+	}
+	return nil
+}
+
+func validateMachOExecutable(input *os.File) error {
+	hostCPU := macho.CpuAmd64
+	if runtime.GOARCH == "arm64" {
+		hostCPU = macho.CpuArm64
+	}
+	file, thinErr := macho.NewFile(input)
+	if thinErr == nil {
+		valid := file.Type == macho.TypeExec && file.Cpu == hostCPU
+		closeErr := file.Close()
+		if !valid {
+			return fmt.Errorf("missing %s executable image", runtime.GOARCH)
+		}
+		return closeErr
+	}
+	fat, err := macho.NewFatFile(input)
+	if err != nil {
+		return thinErr
+	}
+	valid := false
+	for _, arch := range fat.Arches {
+		if arch.Cpu == hostCPU {
+			valid = arch.Type == macho.TypeExec
+			break
+		}
+	}
+	closeErr := fat.Close()
+	if !valid {
+		return fmt.Errorf("missing %s executable image", runtime.GOARCH)
+	}
+	return closeErr
+}
+
+func openFilePath(file *os.File) (string, error) {
+	buffer := make([]byte, unix.PathMax)
+	_, _, errno := unix.Syscall(unix.SYS_FCNTL, file.Fd(), uintptr(unix.F_GETPATH), uintptr(unsafe.Pointer(&buffer[0])))
+	if errno != 0 {
+		return "", errno
+	}
+	if end := bytes.IndexByte(buffer, 0); end >= 0 {
+		buffer = buffer[:end]
+	}
+	if len(buffer) == 0 {
+		return "", fmt.Errorf("F_GETPATH returned an empty path")
+	}
+	return string(buffer), nil
+}

--- a/cmd/internal/projectdriver/executable_other.go
+++ b/cmd/internal/projectdriver/executable_other.go
@@ -1,0 +1,96 @@
+//go:build !darwin
+
+/*
+ * Copyright (c) 2026 The XGo Authors (xgo.dev). All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package projectdriver
+
+import (
+	"debug/elf"
+	"debug/pe"
+	"fmt"
+	"os"
+	"runtime"
+)
+
+func validateHostExecutable(input *os.File, _ string) error {
+	switch runtime.GOOS {
+	case "linux":
+		file, err := elf.NewFile(input)
+		if err != nil {
+			return fmt.Errorf("driver output is not a Linux executable: %w", err)
+		}
+		expected := linuxMachine(runtime.GOARCH)
+		if (file.Type != elf.ET_EXEC && file.Type != elf.ET_DYN) || file.Entry == 0 || expected != elf.EM_NONE && file.Machine != expected {
+			_ = file.Close()
+			return fmt.Errorf("driver output is not a Linux %s executable", runtime.GOARCH)
+		}
+		return file.Close()
+	case "windows":
+		file, err := pe.NewFile(input)
+		if err != nil {
+			return fmt.Errorf("driver output is not a Windows executable: %w", err)
+		}
+		characteristics, expected := file.Characteristics, windowsMachine(runtime.GOARCH)
+		if characteristics&pe.IMAGE_FILE_EXECUTABLE_IMAGE == 0 || characteristics&pe.IMAGE_FILE_DLL != 0 || expected != 0 && file.Machine != expected {
+			_ = file.Close()
+			return fmt.Errorf("driver output is not a Windows %s executable", runtime.GOARCH)
+		}
+		return file.Close()
+	default:
+		return nil
+	}
+}
+
+func linuxMachine(arch string) elf.Machine {
+	switch arch {
+	case "386":
+		return elf.EM_386
+	case "amd64":
+		return elf.EM_X86_64
+	case "arm":
+		return elf.EM_ARM
+	case "arm64":
+		return elf.EM_AARCH64
+	case "loong64":
+		return elf.EM_LOONGARCH
+	case "mips", "mipsle", "mips64", "mips64le":
+		return elf.EM_MIPS
+	case "ppc64", "ppc64le":
+		return elf.EM_PPC64
+	case "riscv64":
+		return elf.EM_RISCV
+	case "s390x":
+		return elf.EM_S390
+	default:
+		return elf.EM_NONE
+	}
+}
+
+func windowsMachine(arch string) uint16 {
+	switch arch {
+	case "386":
+		return pe.IMAGE_FILE_MACHINE_I386
+	case "amd64":
+		return pe.IMAGE_FILE_MACHINE_AMD64
+	case "arm":
+		return pe.IMAGE_FILE_MACHINE_ARMNT
+	case "arm64":
+		return pe.IMAGE_FILE_MACHINE_ARM64
+	default:
+		return 0
+	}
+}

--- a/cmd/internal/projectdriver/fixture_test.go
+++ b/cmd/internal/projectdriver/fixture_test.go
@@ -1,0 +1,289 @@
+/*
+ * Copyright (c) 2026 The XGo Authors (xgo.dev). All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package projectdriver
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/goplus/xgo/x/xgoprojs"
+)
+
+type driverFixture struct {
+	root      string
+	app       string
+	project   string
+	framework string
+	mainFile  string
+}
+
+func newDriverFixture(t *testing.T) driverFixture {
+	t.Helper()
+	t.Setenv("GOWORK", "off")
+	root := t.TempDir()
+	app := filepath.Join(root, "app")
+	project := filepath.Join(app, "game")
+	framework := filepath.Join(root, "framework")
+	mustMkdirAll(t, filepath.Join(project, "pack"))
+	mustMkdirAll(t, filepath.Join(framework, "cmd", "driver"))
+	mustWriteFile(t, filepath.Join(app, "go.mod"), `module example.test/app
+
+go 1.25
+
+require example.test/framework v1.2.3 //xgo:class
+
+replace example.test/framework => ../framework
+`)
+	mustWriteFile(t, filepath.Join(framework, "go.mod"), "module example.test/framework\n\ngo 1.25\n")
+	mustWriteFile(t, filepath.Join(framework, "gox.mod"), `xgo 1.8
+
+project main.foo Game example.test/framework
+class *.bar Worker
+pack pack index.data
+driver v1 example.test/framework/cmd/driver
+`)
+	mustWriteFile(t, filepath.Join(framework, "cmd", "driver", "main.go"), fakeDriverSource)
+	mainFile := filepath.Join(project, "main.foo")
+	mustWriteFile(t, mainFile, "// fake project source\n")
+	mustWriteFile(t, filepath.Join(project, "pack", "index.data"), "{}\n")
+	return driverFixture{root: root, app: app, project: project, framework: framework, mainFile: mainFile}
+}
+
+func (f driverFixture) resolver(t *testing.T, flags ...string) *Resolver {
+	t.Helper()
+	resolver, err := NewResolver(context.Background(), f.app, flags)
+	if err != nil {
+		t.Fatal(err)
+	}
+	resolver.xgoVersion = "v99.0.0"
+	return resolver
+}
+
+func resolveDriver(t *testing.T, resolver *Resolver, target xgoprojs.Proj) *Driver {
+	t.Helper()
+	driver, err := resolver.Resolve(context.Background(), target)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return driver
+}
+func setFixtureRequiredXGo(t *testing.T, fixture driverFixture, version string) {
+	t.Helper()
+	goxmodPath := filepath.Join(fixture.framework, "gox.mod")
+	goxmod, err := os.ReadFile(goxmodPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	updated := strings.Replace(string(goxmod), "xgo 1.8", "xgo "+version, 1)
+	if updated == string(goxmod) {
+		t.Fatalf("fixture gox.mod has no expected xgo directive: %s", goxmod)
+	}
+	if err := os.WriteFile(goxmodPath, []byte(updated), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func mustMkdirAll(t *testing.T, path string) {
+	t.Helper()
+	if err := os.MkdirAll(path, 0o755); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func mustWriteFile(t *testing.T, path, content string) {
+	t.Helper()
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func mustModuleFile(t *testing.T, path, module string) {
+	t.Helper()
+	mustWriteFile(t, path, "module "+module+"\n\ngo 1.25\n")
+}
+
+func mustOverlay(t *testing.T, root string, replacements map[string]string) string {
+	t.Helper()
+	path := filepath.Join(root, "overlay.json")
+	data, err := json.Marshal(overlayJSON{Replace: replacements})
+	if err != nil {
+		t.Fatal(err)
+	}
+	mustWriteFile(t, path, string(data))
+	return path
+}
+
+func mustPolicies(t *testing.T, cwd string, cli ...string) parsedFlags {
+	t.Helper()
+	policy, err := preparePolicies(context.Background(), cwd, cli)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return policy
+}
+
+func mustGraph(t *testing.T, dir string, policy GraphPolicy) *effectiveGraph {
+	t.Helper()
+	graph, err := loadEffectiveGraph(context.Background(), dir, policy)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return graph
+}
+
+func writableModuleCache(t *testing.T) string {
+	t.Helper()
+	cache := t.TempDir()
+	t.Cleanup(func() {
+		_ = filepath.Walk(cache, func(path string, info os.FileInfo, err error) error {
+			if err != nil {
+				return nil
+			}
+			if info.IsDir() {
+				return os.Chmod(path, 0o700)
+			}
+			return os.Chmod(path, 0o600)
+		})
+	})
+	return cache
+}
+
+func canonicalDir(t *testing.T, path string) string {
+	t.Helper()
+	got, err := canonicalExistingDir(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return got
+}
+
+func canonicalFile(t *testing.T, path string) string {
+	t.Helper()
+	got, err := canonicalExistingFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return got
+}
+
+func mustRunGo(t *testing.T, dir, goWork string, args ...string) {
+	t.Helper()
+	cmd := exec.Command("go", args...)
+	cmd.Dir = dir
+	cmd.Env = withNeutralGOFLAGS(replaceEnv(os.Environ(), "GOWORK", goWork))
+	if output, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("go %s: %v\n%s", strings.Join(args, " "), err, output)
+	}
+}
+
+func unsetTestEnv(t *testing.T, key string) {
+	t.Helper()
+	value, ok := os.LookupEnv(key)
+	if err := os.Unsetenv(key); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() {
+		if ok {
+			_ = os.Setenv(key, value)
+		} else {
+			_ = os.Unsetenv(key)
+		}
+	})
+}
+
+func useDriverCapableXGo(t *testing.T) {
+	t.Helper()
+	previous := currentXGoVersion
+	currentXGoVersion = func() string { return "v99.0.0" }
+	t.Cleanup(func() { currentXGoVersion = previous })
+}
+
+func environmentValue(env []string, key string) (string, bool) {
+	for _, entry := range env {
+		name, value, ok := strings.Cut(entry, "=")
+		if ok && name == key {
+			return value, true
+		}
+	}
+	return "", false
+}
+
+const fakeDriverSource = `package main
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"runtime"
+	"strconv"
+	"strings"
+	"time"
+)
+
+func main() {
+	if marker := os.Getenv("FAKE_DRIVER_MARKER"); marker != "" {
+		_ = os.WriteFile(marker, []byte("started"), 0600)
+	}
+	if value := os.Getenv("FAKE_DRIVER_EXIT"); value != "" {
+		code, _ := strconv.Atoi(value)
+		os.Exit(code)
+	}
+	if os.Getenv("FAKE_DRIVER_BLOCK") == "1" {
+		for {
+			time.Sleep(time.Hour)
+		}
+	}
+	if len(os.Args) < 3 || os.Args[1] != "xgo-driver-v1" {
+		os.Exit(90)
+	}
+	switch os.Args[2] {
+	case "run":
+		for i, arg := range os.Args[3:] {
+			if arg == "--" {
+				fmt.Printf("run-args=%s\n", strings.Join(os.Args[i+4:], "|"))
+				return
+			}
+		}
+		os.Exit(91)
+	case "build":
+		var output string
+		for _, arg := range os.Args[3:] {
+			if strings.HasPrefix(arg, "--output=") {
+				output = strings.TrimPrefix(arg, "--output=")
+			}
+		}
+		self, err := os.Executable()
+		if err != nil { panic(err) }
+		data, err := os.ReadFile(self)
+		if err != nil { panic(err) }
+		if err := os.WriteFile(output, data, 0755); err != nil { panic(err) }
+		if runtime.GOOS == "darwin" {
+			if data, err := exec.Command("/usr/bin/codesign", "--force", "--sign", "-", output).CombinedOutput(); err != nil {
+				fmt.Fprintln(os.Stderr, string(data))
+				os.Exit(93)
+			}
+		}
+	default:
+		os.Exit(92)
+	}
+}
+`

--- a/cmd/internal/projectdriver/flags.go
+++ b/cmd/internal/projectdriver/flags.go
@@ -1,0 +1,229 @@
+/*
+ * Copyright (c) 2026 The XGo Authors (xgo.dev). All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package projectdriver
+
+import (
+	"fmt"
+	"path/filepath"
+	"strconv"
+	"strings"
+)
+
+type parsedFlags struct {
+	graph    GraphPolicy
+	build    BuildPolicy
+	rejected []string
+}
+
+func (p BuildPolicy) goBuildFlags() []string {
+	return p.formatFlags("")
+}
+
+func (p BuildPolicy) protocolFlags() []string {
+	return p.formatFlags("=true")
+}
+
+func (p BuildPolicy) formatFlags(enabledSuffix string) []string {
+	flags := make([]string, 0, 5)
+	if p.Verbose {
+		flags = append(flags, "-v"+enabledSuffix)
+	}
+	if p.Trace {
+		flags = append(flags, "-x"+enabledSuffix)
+	}
+	if p.KeepWork {
+		flags = append(flags, "-work"+enabledSuffix)
+	}
+	if p.TrimPath {
+		flags = append(flags, "-trimpath=true")
+	}
+	if p.DisableBuildVCS {
+		flags = append(flags, "-buildvcs=false")
+	}
+	return flags
+}
+
+func (p GraphPolicy) goFlags() []string {
+	flags := make([]string, 0, 3)
+	if p.ModMode != "" {
+		flags = append(flags, "-mod="+string(p.ModMode))
+	}
+	if p.ModFile != "" {
+		flags = append(flags, "-modfile="+p.ModFile)
+	}
+	if p.Overlay != "" {
+		flags = append(flags, "-overlay="+p.Overlay)
+	}
+	return flags
+}
+
+func (p GraphPolicy) goArgs(command string, args ...string) []string {
+	ret := make([]string, 1, 1+len(args)+3)
+	ret[0] = command
+	ret = append(ret, p.goFlags()...)
+	return append(ret, args...)
+}
+
+// parseDriverFlags extracts discovery policy and defers rejected flags.
+func parseDriverFlags(projectDir, goCommand, goWork, ambient string, cli []string) (parsedFlags, error) {
+	ambientArgs, err := splitQuotedFields(ambient)
+	if err != nil {
+		return parsedFlags{}, fmt.Errorf("invalid GOFLAGS: %w", err)
+	}
+	all := append(ambientArgs, cli...)
+	var ret parsedFlags
+	ret.graph.GoCommand = goCommand
+	ret.graph.GoWork = goWork
+	for _, arg := range all {
+		name, value, ok := splitCanonicalFlag(arg)
+		if !ok {
+			ret.rejected = append(ret.rejected, arg)
+			continue
+		}
+		switch name {
+		case "mod":
+			mode := modMode(value)
+			switch mode {
+			case modModeMod, modModeReadonly, modModeVendor:
+			default:
+				// Defer malformed policy until a driver is selected. Legacy
+				// commands still report their own flag errors.
+				ret.rejected = append(ret.rejected, arg)
+				continue
+			}
+			ret.graph.ModMode = mode
+		case "modfile", "overlay":
+			if value == "" {
+				ret.rejected = append(ret.rejected, arg)
+				continue
+			}
+			path, err := canonicalFlagPath(projectDir, value)
+			if err != nil {
+				ret.rejected = append(ret.rejected, arg)
+				continue
+			}
+			if name == "modfile" {
+				ret.graph.ModFile = path
+			} else {
+				ret.graph.Overlay = path
+				// Discover through the overlay; reject it for matched drivers.
+				ret.rejected = append(ret.rejected, arg)
+			}
+		case "v", "x", "work", "trimpath":
+			v, err := strconv.ParseBool(value)
+			if err != nil {
+				ret.rejected = append(ret.rejected, arg)
+				continue
+			}
+			switch name {
+			case "v":
+				ret.build.Verbose = v
+			case "x":
+				ret.build.Trace = v
+			case "work":
+				ret.build.KeepWork = v
+			case "trimpath":
+				ret.build.TrimPath = v
+			}
+		case "buildvcs":
+			if value != "false" && value != "auto" {
+				ret.rejected = append(ret.rejected, arg)
+				continue
+			}
+			ret.build.DisableBuildVCS = value == "false"
+		default:
+			ret.rejected = append(ret.rejected, "-"+name)
+		}
+	}
+	return ret, nil
+}
+
+func (p parsedFlags) validateDriver() error {
+	if len(p.rejected) == 0 {
+		return nil
+	}
+	return fmt.Errorf("driver v1 does not support flag %s", p.rejected[0])
+}
+
+func splitCanonicalFlag(arg string) (name, value string, ok bool) {
+	if !strings.HasPrefix(arg, "-") || arg == "-" || arg == "--" {
+		return "", "", false
+	}
+	arg = strings.TrimPrefix(arg, "-")
+	if strings.HasPrefix(arg, "-") {
+		arg = strings.TrimPrefix(arg, "-")
+	}
+	if at := strings.IndexByte(arg, '='); at >= 0 {
+		name, value = arg[:at], arg[at+1:]
+	} else {
+		name, value = arg, "true"
+	}
+	return name, value, name != ""
+}
+
+func canonicalFlagPath(base, path string) (string, error) {
+	if !filepath.IsAbs(path) {
+		path = filepath.Join(base, path)
+	}
+	abs, err := filepath.Abs(path)
+	if err != nil {
+		return "", err
+	}
+	abs = filepath.Clean(abs)
+	if real, err := filepath.EvalSymlinks(abs); err == nil {
+		abs = real
+	}
+	return abs, nil
+}
+
+func isQuotedFieldSpace(c byte) bool {
+	return c == ' ' || c == '\t' || c == '\n' || c == '\r'
+}
+
+// splitQuotedFields mirrors the Go command's GOFLAGS parser.
+func splitQuotedFields(s string) ([]string, error) {
+	var fields []string
+	for len(s) > 0 {
+		for len(s) > 0 && isQuotedFieldSpace(s[0]) {
+			s = s[1:]
+		}
+		if len(s) == 0 {
+			break
+		}
+		if s[0] == '\'' || s[0] == '"' {
+			quote := s[0]
+			s = s[1:]
+			i := 0
+			for i < len(s) && s[i] != quote {
+				i++
+			}
+			if i >= len(s) {
+				return nil, fmt.Errorf("unterminated %c string", quote)
+			}
+			fields = append(fields, s[:i])
+			s = s[i+1:]
+			continue
+		}
+		i := 0
+		for i < len(s) && !isQuotedFieldSpace(s[i]) {
+			i++
+		}
+		fields = append(fields, s[:i])
+		s = s[i:]
+	}
+	return fields, nil
+}

--- a/cmd/internal/projectdriver/flags_test.go
+++ b/cmd/internal/projectdriver/flags_test.go
@@ -1,0 +1,176 @@
+/*
+ * Copyright (c) 2026 The XGo Authors (xgo.dev). All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package projectdriver
+
+import (
+	"path/filepath"
+	"reflect"
+	"strings"
+	"testing"
+)
+
+func TestSplitQuotedFields(t *testing.T) {
+	tests := []struct {
+		name string
+		in   string
+		want []string
+	}{
+		{
+			name: "whole fields may be quoted",
+			in:   `-buildvcs=false '-overlay=a b.json' "-modfile=x.mod" -trimpath`,
+			want: []string{"-buildvcs=false", "-overlay=a b.json", "-modfile=x.mod", "-trimpath"},
+		},
+		{
+			name: "backslashes are literal",
+			in:   `"-modfile=C:\work\alt.mod" -overlay=C:\work\overlay.json -x=foo\`,
+			want: []string{`-modfile=C:\work\alt.mod`, `-overlay=C:\work\overlay.json`, `-x=foo\`},
+		},
+		{
+			name: "quotes inside fields are literal",
+			in:   `-overlay="a b.json" "-modfile=x.mod"`,
+			want: []string{`-overlay="a`, `b.json"`, "-modfile=x.mod"},
+		},
+		{
+			name: "unterminated interior quote is literal",
+			in:   `-x="unterminated`,
+			want: []string{`-x="unterminated`},
+		},
+		{
+			name: "empty quoted field",
+			in:   `'' ""`,
+			want: []string{"", ""},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := splitQuotedFields(tt.in)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Fatalf("splitQuotedFields(%q) = %#v, want %#v", tt.in, got, tt.want)
+			}
+		})
+	}
+	for _, in := range []string{`"unterminated`, `'unterminated`} {
+		if _, err := splitQuotedFields(in); err == nil {
+			t.Fatalf("splitQuotedFields(%q) succeeded", in)
+		}
+	}
+}
+
+func TestParseDriverFlags(t *testing.T) {
+	dir := t.TempDir()
+	got, err := parseDriverFlags(dir, "/usr/bin/go", "off",
+		`-buildvcs=false -trimpath=true -mod=readonly`,
+		[]string{"-v=true", "-x=false", "-work=true", "-trimpath=false", "-buildvcs=auto", "-mod=mod", "-modfile=alt.mod"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	wantGraph := []string{
+		"-mod=mod",
+		"-modfile=" + filepath.Join(dir, "alt.mod"),
+	}
+	if !reflect.DeepEqual(got.graph.goFlags(), wantGraph) {
+		t.Fatalf("graph flags = %#v, want %#v", got.graph.goFlags(), wantGraph)
+	}
+	if got.graph.ModMode != modModeMod || got.graph.ModFile != filepath.Join(dir, "alt.mod") || !got.build.Verbose || got.build.Trace || !got.build.KeepWork {
+		t.Fatalf("unexpected policies: %#v", got)
+	}
+	if got.build.DisableBuildVCS || got.build.TrimPath {
+		t.Fatalf("explicit defaults were not normalized: %#v", got.build)
+	}
+	if err := got.validateDriver(); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestParseDriverFlagsDefersOverlayRejection(t *testing.T) {
+	dir := t.TempDir()
+	got, err := parseDriverFlags(dir, "/usr/bin/go", "off", `'-overlay=old overlay.json'`, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	wantGraph := []string{"-overlay=" + filepath.Join(dir, "old overlay.json")}
+	if !reflect.DeepEqual(got.graph.goFlags(), wantGraph) {
+		t.Fatalf("graph flags = %#v, want %#v", got.graph.goFlags(), wantGraph)
+	}
+	if err := got.validateDriver(); err == nil || !strings.Contains(err.Error(), "overlay") {
+		t.Fatalf("validateDriver() = %v, want deferred overlay rejection", err)
+	}
+}
+
+func TestParseDriverFlagsAcceptsDoubleDashForms(t *testing.T) {
+	dir := t.TempDir()
+	got, err := parseDriverFlags(dir, "/usr/bin/go", "off", `--mod=readonly --trimpath`, []string{"--mod=mod", "--buildvcs=false"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if want := []string{"-mod=mod"}; !reflect.DeepEqual(got.graph.goFlags(), want) {
+		t.Fatalf("graph flags = %#v, want %#v", got.graph.goFlags(), want)
+	}
+	if !got.build.TrimPath || !got.build.DisableBuildVCS {
+		t.Fatalf("build flags = %#v", got.build)
+	}
+	if err := got.validateDriver(); err != nil {
+		t.Fatal(err)
+	}
+	for _, flag := range []string{"--", "---trimpath"} {
+		got, err := parseDriverFlags(dir, "/usr/bin/go", "off", "", []string{flag})
+		if err != nil {
+			t.Fatal(err)
+		}
+		if err := got.validateDriver(); err == nil {
+			t.Fatalf("invalid flag %q was accepted", flag)
+		}
+	}
+}
+
+func TestBuildPolicyFlagForms(t *testing.T) {
+	policy := BuildPolicy{
+		TrimPath: true,
+		Verbose:  true,
+		Trace:    true,
+		KeepWork: true,
+	}
+	wantGo := []string{"-v", "-x", "-work", "-trimpath=true"}
+	wantProtocol := []string{"-v=true", "-x=true", "-work=true", "-trimpath=true"}
+	if got := policy.goBuildFlags(); !reflect.DeepEqual(got, wantGo) {
+		t.Fatalf("go build flags = %#v, want %#v", got, wantGo)
+	}
+	if got := policy.protocolFlags(); !reflect.DeepEqual(got, wantProtocol) {
+		t.Fatalf("protocol flags = %#v, want %#v", got, wantProtocol)
+	}
+}
+
+func TestParseDriverFlagsRejected(t *testing.T) {
+	for _, flag := range []string{"-n=true", "-tags=foo", "-buildmode=pie", "-buildvcs=true", "-trimpath=invalid", "-v=invalid", "-x=invalid", "-work=invalid"} {
+		got, err := parseDriverFlags(t.TempDir(), "/usr/bin/go", "off", "", []string{flag})
+		if err != nil {
+			t.Fatalf("parseDriverFlags(%q): %v", flag, err)
+		}
+		validationErr := got.validateDriver()
+		if validationErr == nil || !strings.Contains(validationErr.Error(), strings.Split(strings.TrimPrefix(flag, "-"), "=")[0]) {
+			t.Fatalf("validateDriver(%q) = %v", flag, validationErr)
+		}
+		if strings.Contains(flag, "=invalid") {
+			if !strings.Contains(validationErr.Error(), flag) {
+				t.Fatalf("validateDriver(%q) = %v, want original flag", flag, validationErr)
+			}
+		}
+	}
+}

--- a/cmd/internal/projectdriver/graph.go
+++ b/cmd/internal/projectdriver/graph.go
@@ -1,0 +1,315 @@
+/*
+ * Copyright (c) 2026 The XGo Authors (xgo.dev). All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package projectdriver
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"sort"
+	"strings"
+
+	"github.com/goplus/mod/modload"
+	gomodfile "golang.org/x/mod/modfile"
+)
+
+var errNoGoModule = errors.New("driver discovery requires a Go module")
+
+type fileIdentity = modload.FileIdentity
+
+type effectiveGraph struct {
+	Target        ResolvedModule
+	Modules       map[string]ResolvedModule
+	ClassModules  []ResolvedModule
+	TargetModFile fileIdentity
+	files         *graphFileView
+}
+
+type goListModule struct {
+	Path    string
+	Version string
+	Replace *goListModule
+	Main    bool
+	Dir     string
+	GoMod   string
+	Error   *struct {
+		Err string
+	}
+}
+
+func loadEffectiveGraph(ctx context.Context, projectDir string, policy GraphPolicy) (*effectiveGraph, error) {
+	view, err := newGraphFileView(policy, projectDir)
+	if err != nil {
+		return nil, err
+	}
+	stdout, stderr, err := runGraphCommand(ctx, policy, projectDir, "go list -m", policy.goArgs("list", "-m", "-json", "all")...)
+	if err != nil {
+		message := string(stderr)
+		if strings.Contains(message, "go.mod file not found") || strings.Contains(message, "cannot find main module") {
+			return nil, fmt.Errorf("%w: %s", errNoGoModule, strings.TrimSpace(message))
+		}
+		return nil, err
+	}
+	var raw []goListModule
+	dec := json.NewDecoder(bytes.NewReader(stdout))
+	for {
+		var module goListModule
+		if err := dec.Decode(&module); errors.Is(err, io.EOF) {
+			break
+		} else if err != nil {
+			return nil, fmt.Errorf("decode effective module graph: %w", err)
+		}
+		raw = append(raw, module)
+	}
+	if len(raw) == 0 {
+		return nil, fmt.Errorf("effective module graph is empty")
+	}
+	projectDir, err = canonicalExistingDir(projectDir)
+	if err != nil {
+		return nil, err
+	}
+	ret := &effectiveGraph{Modules: make(map[string]ResolvedModule, len(raw))}
+	for _, module := range raw {
+		resolved, err := normalizeGraphModule(module)
+		if err != nil {
+			return nil, err
+		}
+		if _, exists := ret.Modules[resolved.Selected.Path]; exists {
+			return nil, fmt.Errorf("duplicate logical module %q in effective graph", resolved.Selected.Path)
+		}
+		ret.Modules[resolved.Selected.Path] = resolved
+	}
+	ret.Target, err = selectTargetModule(projectDir, ret.Modules)
+	if err != nil {
+		return nil, err
+	}
+	modfilePath := ret.Target.Effective().GoMod
+	if policy.ModFile != "" {
+		modfilePath = policy.ModFile
+	}
+	identity, classPaths, err := readTargetModFileView(modfilePath, view)
+	if err != nil {
+		return nil, err
+	}
+	classModules, err := materializeClassModules(ctx, projectDir, policy, ret.Modules, classPaths)
+	if err != nil {
+		return nil, err
+	}
+	ret.ClassModules = classModules
+	ret.TargetModFile = identity
+	ret.files = view
+	return ret, nil
+}
+
+func materializeClassModules(ctx context.Context, dir string, policy GraphPolicy, modules map[string]ResolvedModule, paths []string) ([]ResolvedModule, error) {
+	resolved := make([]ResolvedModule, 0, len(paths))
+	for _, path := range paths {
+		module, ok := modules[path]
+		if !ok {
+			return nil, fmt.Errorf("class module %q is absent from the effective graph", path)
+		}
+		if module.Effective().Dir == "" || module.Effective().GoMod == "" {
+			var err error
+			module, err = downloadGraphModule(ctx, dir, policy, module)
+			if err != nil {
+				return nil, fmt.Errorf("materialize class module %q: %w", path, err)
+			}
+			modules[path] = module
+		}
+		resolved = append(resolved, module)
+	}
+	return resolved, nil
+}
+
+func selectTargetModule(projectDir string, modules map[string]ResolvedModule) (ResolvedModule, error) {
+	bestRoot := ""
+	candidates := make([]ResolvedModule, 0, 1)
+	for _, module := range modules {
+		root := module.Effective().Dir
+		if root == "" || !pathWithin(root, projectDir) {
+			continue
+		}
+		switch {
+		case len(root) > len(bestRoot):
+			bestRoot = root
+			candidates = append(candidates[:0], module)
+		case len(root) == len(bestRoot):
+			candidates = append(candidates, module)
+		}
+	}
+	if len(candidates) == 0 {
+		return ResolvedModule{}, fmt.Errorf("project directory %q is outside the effective module graph", projectDir)
+	}
+	if len(candidates) == 1 {
+		return candidates[0], nil
+	}
+	paths := make([]string, len(candidates))
+	for i, candidate := range candidates {
+		paths[i] = candidate.Selected.Path
+	}
+	sort.Strings(paths)
+	return ResolvedModule{}, fmt.Errorf("project directory %q has ambiguous effective module owners: %s", projectDir, strings.Join(paths, ", "))
+}
+
+type goDownloadModule struct {
+	Path    string
+	Version string
+	Dir     string
+	GoMod   string
+	Error   string
+}
+
+func downloadGraphModule(ctx context.Context, dir string, policy GraphPolicy, resolved ResolvedModule) (ResolvedModule, error) {
+	effective := resolved.Effective()
+	if effective.Version == "" {
+		return ResolvedModule{}, fmt.Errorf("local effective source is missing")
+	}
+	query := effective.Path + "@" + effective.Version
+	stdout, _, err := runGraphCommand(ctx, policy, dir, "go mod download "+query, "mod", "download", "-json", query)
+	if err != nil {
+		return ResolvedModule{}, err
+	}
+	var downloaded goDownloadModule
+	if err := json.Unmarshal(stdout, &downloaded); err != nil {
+		return ResolvedModule{}, fmt.Errorf("decode downloaded module: %w", err)
+	}
+	if downloaded.Error != "" {
+		return ResolvedModule{}, errors.New(downloaded.Error)
+	}
+	if downloaded.Path != effective.Path || downloaded.Version != effective.Version {
+		return ResolvedModule{}, fmt.Errorf("downloaded module identity %s@%s does not match %s", downloaded.Path, downloaded.Version, query)
+	}
+	sourceDir, goMod, err := canonicalModuleSource(effective.Path, downloaded.Dir, downloaded.GoMod)
+	if err != nil {
+		return ResolvedModule{}, err
+	}
+	if resolved.Replace == nil {
+		resolved.Selected.Dir, resolved.Selected.GoMod = sourceDir, goMod
+	} else {
+		resolved.Replace.Dir, resolved.Replace.GoMod = sourceDir, goMod
+	}
+	if err := resolved.Validate(); err != nil {
+		return ResolvedModule{}, fmt.Errorf("downloaded module %q: %w", query, err)
+	}
+	return resolved, nil
+}
+
+func normalizeListedModule(module goListModule) (ResolvedModule, error) {
+	return normalizeModule(module, true)
+}
+
+func normalizeGraphModule(module goListModule) (ResolvedModule, error) {
+	return normalizeModule(module, false)
+}
+
+func normalizeModule(module goListModule, requireSource bool) (ResolvedModule, error) {
+	if module.Error != nil && module.Error.Err != "" {
+		return ResolvedModule{}, fmt.Errorf("module %q: %s", module.Path, module.Error.Err)
+	}
+	if module.Path == "" {
+		return ResolvedModule{}, fmt.Errorf("effective graph contains a module with no path")
+	}
+	ret := ResolvedModule{
+		Selected: ModuleRef{Path: module.Path, Version: module.Version},
+		Main:     module.Main,
+	}
+	if module.Replace == nil {
+		if !requireSource && (module.Dir == "" || module.GoMod == "") {
+			return ret, nil
+		}
+		dir, goMod, err := canonicalModuleSource(module.Path, module.Dir, module.GoMod)
+		if err != nil {
+			return ResolvedModule{}, err
+		}
+		ret.Selected.Dir, ret.Selected.GoMod = dir, goMod
+		if err := ret.Validate(); err != nil {
+			return ResolvedModule{}, fmt.Errorf("module %q: %w", module.Path, err)
+		}
+		return ret, nil
+	}
+	if !requireSource && (module.Replace.Dir == "" || module.Replace.GoMod == "") {
+		replacePath := module.Replace.Path
+		ret.Replace = &ModuleRef{Path: replacePath, Version: module.Replace.Version}
+		return ret, nil
+	}
+	dir, goMod, err := canonicalModuleSource(module.Replace.Path, module.Replace.Dir, module.Replace.GoMod)
+	if err != nil {
+		return ResolvedModule{}, err
+	}
+	replacePath := module.Replace.Path
+	if module.Replace.Version == "" {
+		// go list preserves the spelling from the replace directive (often
+		// ../framework). The resolved graph contract carries the canonical
+		// filesystem identity for a local replacement.
+		replacePath = dir
+	}
+	ret.Replace = &ModuleRef{
+		Path:    replacePath,
+		Version: module.Replace.Version,
+		Dir:     dir,
+		GoMod:   goMod,
+	}
+	if err := ret.Validate(); err != nil {
+		return ResolvedModule{}, fmt.Errorf("module %q: %w", module.Path, err)
+	}
+	return ret, nil
+}
+
+func canonicalModuleSource(path, dir, goMod string) (string, string, error) {
+	if dir == "" || goMod == "" {
+		return "", "", fmt.Errorf("effective source for module %q is incomplete (vendor mode is unsupported for class projects)", path)
+	}
+	canonicalDir, err := canonicalExistingDir(dir)
+	if err != nil {
+		return "", "", fmt.Errorf("module %q directory: %w", path, err)
+	}
+	canonicalGoMod, err := canonicalExistingFile(goMod)
+	if err != nil {
+		return "", "", fmt.Errorf("module %q go.mod: %w", path, err)
+	}
+	return canonicalDir, canonicalGoMod, nil
+}
+
+func readTargetModFile(path string) (fileIdentity, []string, error) {
+	return readTargetModFileView(path, nil)
+}
+
+func readTargetModFileView(path string, view *graphFileView) (fileIdentity, []string, error) {
+	canonical, err := view.canonicalFile(path)
+	if err != nil {
+		return fileIdentity{}, nil, fmt.Errorf("effective target modfile: %w", err)
+	}
+	data, err := view.readFile(canonical)
+	if err != nil {
+		return fileIdentity{}, nil, fmt.Errorf("read effective target modfile: %w", err)
+	}
+	parsed, err := gomodfile.Parse(canonical, data, nil)
+	if err != nil {
+		return fileIdentity{}, nil, err
+	}
+	classMods := make([]string, 0)
+	for _, require := range parsed.Require {
+		if require.Syntax == nil || !modload.HasClassMarker(require.Syntax.Suffix) {
+			continue
+		}
+		classMods = append(classMods, require.Mod.Path)
+	}
+	return fileIdentity{Path: canonical, SHA256: sha256Bytes(data)}, classMods, nil
+}

--- a/cmd/internal/projectdriver/graph_command.go
+++ b/cmd/internal/projectdriver/graph_command.go
@@ -1,0 +1,186 @@
+/*
+ * Copyright (c) 2026 The XGo Authors (xgo.dev). All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package projectdriver
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+// A non-empty no-op masks GOFLAGS persisted by go env -w.
+const neutralGOFLAGS = "-x=false"
+
+func runCapturedCommand(cmd *exec.Cmd, display string) (stdout, stderr []byte, err error) {
+	var out, errOut bytes.Buffer
+	cmd.Stdout, cmd.Stderr = &out, &errOut
+	if err := cmd.Run(); err != nil {
+		return out.Bytes(), errOut.Bytes(), commandError(display, err, errOut.String())
+	}
+	return out.Bytes(), errOut.Bytes(), nil
+}
+
+func commandError(name string, err error, stderr string) error {
+	if message := strings.TrimSpace(stderr); message != "" {
+		return fmt.Errorf("%s: %w: %s", name, err, message)
+	}
+	return fmt.Errorf("%s: %w", name, err)
+}
+
+func graphCommand(ctx context.Context, policy GraphPolicy, dir string, args ...string) *exec.Cmd {
+	cmd := exec.CommandContext(ctx, policy.GoCommand, args...)
+	cmd.Dir = dir
+	cmd.Env = graphEnvironment(os.Environ(), policy.GoWork)
+	return cmd
+}
+
+func runGraphCommand(ctx context.Context, policy GraphPolicy, dir, display string, args ...string) (stdout, stderr []byte, err error) {
+	stdout, stderr, err = runCapturedCommand(graphCommand(ctx, policy, dir, args...), display)
+	if err != nil {
+		return stdout, stderr, err
+	}
+	return stdout, nil, nil
+}
+
+func preparePolicies(ctx context.Context, cwd string, cli []string) (parsedFlags, error) {
+	goCommand, err := hostGoCommand()
+	if err != nil {
+		return parsedFlags{}, err
+	}
+	ambient, err := ambientGOFLAGS(ctx, goCommand, cwd)
+	if err != nil {
+		return parsedFlags{}, err
+	}
+	policy, err := parseDriverFlags(cwd, goCommand, "off", ambient, cli)
+	if err != nil {
+		return parsedFlags{}, err
+	}
+	policy, err = sanitizeGraphFlags(policy)
+	if err != nil {
+		return parsedFlags{}, err
+	}
+	// GOWORK is independent of graph flags, which stay in argv to preserve
+	// canonical paths without introducing a second quoting grammar.
+	goWork, err := goEnvValueWithEnvironment(ctx, goCommand, cwd, "GOWORK", withNeutralGOFLAGS(os.Environ()))
+	if err != nil {
+		return parsedFlags{}, err
+	}
+	if goWork == "" || goWork == "off" {
+		policy.graph.GoWork = "off"
+	} else {
+		goWork, err = canonicalExistingFile(goWork)
+		if err != nil {
+			return parsedFlags{}, fmt.Errorf("effective go.work: %w", err)
+		}
+		policy.graph.GoWork = goWork
+	}
+	return policy, nil
+}
+
+func ambientGOFLAGS(ctx context.Context, goCommand, dir string) (string, error) {
+	// Read non-empty OS values directly so malformed flags remain deferred.
+	if value := os.Getenv("GOFLAGS"); value != "" {
+		return value, nil
+	}
+	return goEnvValue(ctx, goCommand, dir, "GOFLAGS")
+}
+
+// sanitizeGraphFlags defers missing graph files as driver-only policy errors.
+func sanitizeGraphFlags(policy parsedFlags) (parsedFlags, error) {
+	if path := policy.graph.ModFile; path != "" {
+		if _, err := os.Stat(path); os.IsNotExist(err) {
+			policy.rejected = append(policy.rejected, "-modfile="+path)
+			policy.graph.ModFile = ""
+		} else if err != nil {
+			return parsedFlags{}, fmt.Errorf("inspect -modfile input %q: %w", path, err)
+		}
+	}
+	if path := policy.graph.Overlay; path != "" {
+		if _, err := os.Stat(path); os.IsNotExist(err) {
+			policy.rejected = append(policy.rejected, "-overlay="+path)
+			policy.graph.Overlay = ""
+		} else if err != nil {
+			return parsedFlags{}, fmt.Errorf("inspect -overlay input %q: %w", path, err)
+		}
+	}
+	return policy, nil
+}
+
+func hostGoCommand() (string, error) {
+	path, err := exec.LookPath("go")
+	if err != nil {
+		return "", fmt.Errorf("host Go command: %w", err)
+	}
+	canonical, err := canonicalExistingFile(path)
+	if err != nil {
+		return "", fmt.Errorf("host Go command %q: %w", path, err)
+	}
+	return canonical, nil
+}
+
+func goEnvValue(ctx context.Context, goCommand, dir, key string) (string, error) {
+	return goEnvValueWithEnvironment(ctx, goCommand, dir, key, os.Environ())
+}
+
+func goEnvValueWithEnvironment(ctx context.Context, goCommand, dir, key string, env []string) (string, error) {
+	cmd := exec.CommandContext(ctx, goCommand, "env", key)
+	cmd.Dir = dir
+	cmd.Env = env
+	return runGoEnv(cmd, key)
+}
+
+// goModForDir returns the physical owner; -modfile changes content, not roots.
+func goModForDir(ctx context.Context, policy GraphPolicy, dir string) (string, error) {
+	cmd := graphCommand(ctx, policy, dir, "env", "GOMOD")
+	return runGoEnv(cmd, "GOMOD")
+}
+
+func runGoEnv(cmd *exec.Cmd, key string) (string, error) {
+	out, _, err := runCapturedCommand(cmd, "go env "+key)
+	if err != nil {
+		return "", err
+	}
+	return strings.TrimSpace(string(out)), nil
+}
+
+func graphEnvironment(base []string, goWork string) []string {
+	// Graph policy travels in argv; the no-op masks ambient and persisted
+	// GOFLAGS from the authoritative graph command.
+	env := withNeutralGOFLAGS(base)
+	if goWork != "" {
+		env = replaceEnv(env, "GOWORK", goWork)
+	}
+	return env
+}
+
+func withNeutralGOFLAGS(env []string) []string {
+	return replaceEnv(env, "GOFLAGS", neutralGOFLAGS)
+}
+
+func replaceEnv(env []string, key, value string) []string {
+	prefix := key + "="
+	ret := make([]string, 0, len(env)+1)
+	for _, item := range env {
+		if !strings.HasPrefix(item, prefix) {
+			ret = append(ret, item)
+		}
+	}
+	return append(ret, prefix+value)
+}

--- a/cmd/internal/projectdriver/graph_overlay.go
+++ b/cmd/internal/projectdriver/graph_overlay.go
@@ -1,0 +1,239 @@
+/*
+ * Copyright (c) 2026 The XGo Authors (xgo.dev). All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package projectdriver
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+)
+
+// graphFileView models -overlay paths for classification only.
+// The Go command remains authoritative for graph resolution.
+type graphFileView struct {
+	workDir            string
+	replacements       map[string]string
+	replacementParents map[string]struct{}
+}
+
+type overlayJSON struct {
+	Replace map[string]string
+}
+
+func newGraphFileView(policy GraphPolicy, workDir string) (*graphFileView, error) {
+	view := &graphFileView{workDir: workDir}
+	overlay := policy.Overlay
+	if overlay == "" {
+		return view, nil
+	}
+	data, err := os.ReadFile(overlay)
+	if err != nil {
+		return nil, fmt.Errorf("read overlay %q: %w", overlay, err)
+	}
+	var parsed overlayJSON
+	if err := json.Unmarshal(data, &parsed); err != nil {
+		return nil, fmt.Errorf("parse overlay %q: %w", overlay, err)
+	}
+	view.replacements = make(map[string]string, len(parsed.Replace))
+	view.replacementParents = make(map[string]struct{})
+	for from, to := range parsed.Replace {
+		if from == "" {
+			return nil, fmt.Errorf("overlay %q contains an empty replacement path", overlay)
+		}
+		from = overlayPath(workDir, from)
+		if _, duplicate := view.replacements[from]; duplicate {
+			return nil, fmt.Errorf("overlay %q contains duplicate normalized path %q", overlay, from)
+		}
+		view.replacements[from] = overlayPath(workDir, to)
+	}
+	for child, target := range view.replacements {
+		if target == "" {
+			continue
+		}
+		for parent := filepath.Dir(child); parent != child; parent = filepath.Dir(parent) {
+			if parentTarget, ok := view.replacements[parent]; ok && parentTarget != "" {
+				return nil, fmt.Errorf("overlay %q maps both file %q and child %q", overlay, parent, child)
+			}
+			view.replacementParents[parent] = struct{}{}
+			if parent == filepath.Dir(parent) {
+				break
+			}
+		}
+	}
+	return view, nil
+}
+
+func overlayPath(workDir, path string) string {
+	if path == "" {
+		return ""
+	}
+	if !filepath.IsAbs(path) {
+		path = filepath.Join(workDir, path)
+	}
+	return filepath.Clean(path)
+}
+
+func (v *graphFileView) hasOverlay() bool {
+	return v != nil && v.replacements != nil
+}
+
+func (v *graphFileView) logicalPath(path string) string {
+	if !v.hasOverlay() {
+		return path
+	}
+	return overlayPath(v.workDir, path)
+}
+
+func statVisible(path string, matches func(os.FileMode) bool) (bool, error) {
+	info, err := os.Stat(path)
+	if os.IsNotExist(err) {
+		return false, nil
+	}
+	if err != nil {
+		return false, err
+	}
+	return matches(info.Mode()), nil
+}
+
+func (v *graphFileView) readFile(path string) ([]byte, error) {
+	if !v.hasOverlay() {
+		return os.ReadFile(path)
+	}
+	logical := v.logicalPath(path)
+	if actual, ok := v.replacements[logical]; ok {
+		if actual == "" {
+			return nil, &os.PathError{Op: "read", Path: logical, Err: os.ErrNotExist}
+		}
+		return os.ReadFile(actual)
+	}
+	// An exact child replacement wins over an ancestor deletion, as in cmd/go.
+	if _, hidden := v.replacementAncestor(logical); hidden {
+		return nil, &os.PathError{Op: "read", Path: logical, Err: os.ErrNotExist}
+	}
+	return os.ReadFile(logical)
+}
+
+func (v *graphFileView) replacementAncestor(path string) (string, bool) {
+	if !v.hasOverlay() {
+		return "", false
+	}
+	for parent := filepath.Dir(path); parent != path; parent = filepath.Dir(parent) {
+		if actual, ok := v.replacements[parent]; ok {
+			return actual, true
+		}
+		if parent == filepath.Dir(parent) {
+			break
+		}
+	}
+	return "", false
+}
+
+// Replacement destinations remain opaque until Go reads them.
+func (v *graphFileView) hasReplacementChild(path string) bool {
+	if !v.hasOverlay() {
+		return false
+	}
+	_, ok := v.replacementParents[v.logicalPath(path)]
+	return ok
+}
+
+func (v *graphFileView) directoryVisible(dir string) (bool, error) {
+	if !v.hasOverlay() {
+		return statVisible(dir, os.FileMode.IsDir)
+	}
+	logical := v.logicalPath(dir)
+	if _, exact := v.replacements[logical]; exact {
+		return false, nil
+	}
+	_, hasAncestor := v.replacementAncestor(logical)
+	if hasAncestor && !v.hasReplacementChild(logical) {
+		return false, nil
+	}
+	if v.hasReplacementChild(logical) {
+		return true, nil
+	}
+	return statVisible(logical, os.FileMode.IsDir)
+}
+
+func (v *graphFileView) physicalEntries(dir string) ([]os.DirEntry, error) {
+	if !v.hasOverlay() {
+		return os.ReadDir(dir)
+	}
+	logical := v.logicalPath(dir)
+	if _, exact := v.replacements[logical]; exact {
+		return nil, nil
+	}
+	if _, hasAncestor := v.replacementAncestor(logical); hasAncestor {
+		return nil, nil
+	}
+	entries, err := os.ReadDir(logical)
+	if os.IsNotExist(err) && v.hasReplacementChild(logical) {
+		return nil, nil
+	}
+	return entries, err
+}
+
+func (v *graphFileView) regularFileVisible(path string) (bool, error) {
+	if !v.hasOverlay() {
+		return statVisible(path, os.FileMode.IsRegular)
+	}
+	logical := v.logicalPath(path)
+	if actual, exact := v.replacements[logical]; exact {
+		return actual != "", nil
+	}
+	if _, hidden := v.replacementAncestor(logical); hidden {
+		return false, nil
+	}
+	return statVisible(logical, os.FileMode.IsRegular)
+}
+
+func (v *graphFileView) canonicalFile(path string) (string, error) {
+	if !v.hasOverlay() {
+		return canonicalExistingFile(path)
+	}
+	logical := v.logicalPath(path)
+	if actual, exact := v.replacements[logical]; exact {
+		if actual == "" {
+			return "", &os.PathError{Op: "stat", Path: logical, Err: os.ErrNotExist}
+		}
+		return logical, nil
+	}
+	if _, hidden := v.replacementAncestor(logical); hidden {
+		return "", &os.PathError{Op: "stat", Path: logical, Err: os.ErrNotExist}
+	}
+	return canonicalExistingFile(logical)
+}
+
+// Synthetic directories are safe because overlay-backed drivers never execute.
+func (v *graphFileView) canonicalDir(path string) (string, error) {
+	if !v.hasOverlay() {
+		return canonicalExistingDir(path)
+	}
+	logical := v.logicalPath(path)
+	visible, err := v.directoryVisible(logical)
+	if err != nil {
+		return "", err
+	}
+	if !visible {
+		return "", &os.PathError{Op: "stat", Path: logical, Err: os.ErrNotExist}
+	}
+	if v.hasReplacementChild(logical) {
+		return logical, nil
+	}
+	return canonicalExistingDir(logical)
+}

--- a/cmd/internal/projectdriver/graph_overlay_listing.go
+++ b/cmd/internal/projectdriver/graph_overlay_listing.go
@@ -1,0 +1,137 @@
+/*
+ * Copyright (c) 2026 The XGo Authors (xgo.dev). All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package projectdriver
+
+import (
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+)
+
+// regularFileNames merges physical and overlay files without inspecting destinations.
+func (v *graphFileView) regularFileNames(dir string) ([]string, error) {
+	logicalDir := v.logicalPath(dir)
+	entries, err := v.physicalEntries(logicalDir)
+	if err != nil {
+		return nil, err
+	}
+	files := make(map[string]bool, len(entries))
+	for _, entry := range entries {
+		logical := filepath.Join(logicalDir, entry.Name())
+		if v.hasOverlay() {
+			if actual, replaced := v.replacements[logical]; replaced {
+				files[entry.Name()] = actual != ""
+				continue
+			}
+			if v.hasReplacementChild(logical) {
+				continue
+			}
+		}
+		if entry.Type()&os.ModeSymlink != 0 {
+			continue
+		}
+		info, infoErr := entry.Info()
+		if infoErr != nil {
+			return nil, infoErr
+		}
+		if info.Mode().IsRegular() {
+			files[entry.Name()] = true
+		}
+	}
+	if v.hasOverlay() {
+		for logical, actual := range v.replacements {
+			if filepath.Dir(logical) != logicalDir {
+				continue
+			}
+			files[filepath.Base(logical)] = actual != ""
+		}
+	}
+	names := make([]string, 0, len(files))
+	for name, visible := range files {
+		if visible {
+			names = append(names, name)
+		}
+	}
+	sort.Strings(names)
+	return names, nil
+}
+
+// directoryNames returns physical children plus overlay-only directories.
+func (v *graphFileView) directoryNames(dir string) ([]string, error) {
+	logicalDir := overlayPath(v.workDir, dir)
+	visible, err := v.directoryVisible(logicalDir)
+	if err != nil {
+		return nil, err
+	}
+	if !visible {
+		return nil, nil
+	}
+	entries, err := v.physicalEntries(logicalDir)
+	if err != nil {
+		return nil, err
+	}
+	direct := make(map[string]bool, len(entries))
+	for _, entry := range entries {
+		logical := filepath.Join(logicalDir, entry.Name())
+		if _, replaced := v.replacements[logical]; replaced {
+			direct[entry.Name()] = false
+			continue
+		}
+		if v.hasReplacementChild(logical) {
+			direct[entry.Name()] = true
+			continue
+		}
+		if entry.Type()&os.ModeSymlink != 0 {
+			continue
+		}
+		info, infoErr := entry.Info()
+		if infoErr != nil {
+			return nil, infoErr
+		}
+		if info.IsDir() {
+			direct[entry.Name()] = true
+		}
+	}
+	for logical, actual := range v.replacements {
+		if actual == "" || !pathWithin(logicalDir, logical) {
+			continue
+		}
+		rel, relErr := filepath.Rel(logicalDir, logical)
+		if relErr != nil || rel == "." || rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
+			continue
+		}
+		name := rel
+		if at := strings.IndexByte(rel, filepath.Separator); at >= 0 {
+			name = rel[:at]
+		}
+		child := filepath.Join(logicalDir, name)
+		if childActual, exact := v.replacements[child]; exact {
+			direct[name] = childActual == ""
+			continue
+		}
+		direct[name] = true
+	}
+	names := make([]string, 0, len(direct))
+	for name, visible := range direct {
+		if visible {
+			names = append(names, name)
+		}
+	}
+	sort.Strings(names)
+	return names, nil
+}

--- a/cmd/internal/projectdriver/graph_package.go
+++ b/cmd/internal/projectdriver/graph_package.go
@@ -1,0 +1,203 @@
+/*
+ * Copyright (c) 2026 The XGo Authors (xgo.dev). All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package projectdriver
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+)
+
+type goListPackage struct {
+	Dir        string
+	ImportPath string
+	Name       string
+	Module     *goListModule
+	Error      *struct {
+		Err string
+	}
+}
+
+func resolvePackageDirectory(ctx context.Context, graph *effectiveGraph, importPath, workDir string, policy GraphPolicy) (string, ResolvedModule, error) {
+	pkg, err := listPackageTarget(ctx, importPath, workDir, policy)
+	if err != nil {
+		return "", ResolvedModule{}, err
+	}
+	if pkg.ImportPath != importPath {
+		return "", ResolvedModule{}, fmt.Errorf("package target %q resolved as %q", importPath, pkg.ImportPath)
+	}
+	if pkg.Dir == "" || pkg.Module == nil {
+		// XGo-only packages may omit physical fields; resolve them from the graph.
+		return resolveXGoOnlyPackageDirectory(ctx, graph, importPath, policy)
+	}
+	listed, err := normalizeListedModule(*pkg.Module)
+	if err != nil {
+		return "", ResolvedModule{}, fmt.Errorf("package target %q: %w", importPath, err)
+	}
+	module, ok := graph.Modules[listed.Selected.Path]
+	if !ok {
+		return "", ResolvedModule{}, fmt.Errorf("package target %q does not match the effective module graph", importPath)
+	}
+	dir, err := graph.files.canonicalDir(pkg.Dir)
+	if err != nil {
+		return "", ResolvedModule{}, fmt.Errorf("package target %q: %w", importPath, err)
+	}
+	if module.Effective().Dir == "" {
+		// Keep unmarked dependency identity without materializing its source.
+		return dir, module, nil
+	}
+	if !listed.Equal(module) {
+		return "", ResolvedModule{}, fmt.Errorf("package target %q does not match the effective module graph", importPath)
+	}
+	if err := validatePackagePath(module, importPath, dir); err != nil {
+		return "", ResolvedModule{}, err
+	}
+	return dir, module, nil
+}
+
+func validatePackagePath(module ResolvedModule, importPath, dir string) error {
+	if !pathWithin(module.Effective().Dir, dir) {
+		return fmt.Errorf("package target %q escapes module %q", importPath, module.Selected.Path)
+	}
+	return nil
+}
+
+func validatePackageOwnership(ctx context.Context, policy GraphPolicy, module ResolvedModule, importPath, dir string) error {
+	ownerGoMod, err := goModForDir(ctx, policy, dir)
+	if err != nil {
+		return fmt.Errorf("resolve package target %q module ownership: %w", importPath, err)
+	}
+	if ownerGoMod == "" || ownerGoMod == os.DevNull {
+		return fmt.Errorf("package target %q has no module ownership", importPath)
+	}
+	ownerRoot, err := canonicalExistingDir(filepath.Dir(ownerGoMod))
+	if err != nil {
+		return fmt.Errorf("resolve package target %q module ownership: %w", importPath, err)
+	}
+	same, err := sameFile(ownerRoot, module.Effective().Dir)
+	if err != nil {
+		return fmt.Errorf("resolve package target %q module ownership: %w", importPath, err)
+	}
+	if !same {
+		return fmt.Errorf("package target %q crosses a nested module boundary", importPath)
+	}
+	return nil
+}
+
+func moduleOwnsPackage(ctx context.Context, policy GraphPolicy, moduleGoMod, dir string) (bool, error) {
+	ownerGoMod, err := goModForDir(ctx, policy, dir)
+	if err != nil {
+		return false, err
+	}
+	if ownerGoMod == "" || ownerGoMod == os.DevNull {
+		return false, nil
+	}
+	return sameFile(moduleGoMod, ownerGoMod)
+}
+
+func listPackageTarget(ctx context.Context, importPath, workDir string, policy GraphPolicy) (goListPackage, error) {
+	if importPath == "" || strings.Contains(importPath, "@") || strings.Contains(importPath, "...") {
+		return goListPackage{}, fmt.Errorf("driver does not support package target %q", importPath)
+	}
+	stdout, _, err := runGraphCommand(ctx, policy, workDir, "resolve package target "+importPath, policy.goArgs("list", "-e", "-find", "-json", importPath)...)
+	if err != nil {
+		return goListPackage{}, err
+	}
+	dec := json.NewDecoder(bytes.NewReader(stdout))
+	var pkg goListPackage
+	if err := dec.Decode(&pkg); err != nil {
+		return goListPackage{}, fmt.Errorf("decode package target %q: %w", importPath, err)
+	}
+	var extra json.RawMessage
+	if err := dec.Decode(&extra); !errors.Is(err, io.EOF) {
+		if err == nil {
+			return goListPackage{}, fmt.Errorf("package target %q resolved to multiple packages", importPath)
+		}
+		return goListPackage{}, fmt.Errorf("decode package target %q: %w", importPath, err)
+	}
+	return pkg, nil
+}
+
+func resolveXGoOnlyPackageDirectory(ctx context.Context, graph *effectiveGraph, importPath string, policy GraphPolicy) (string, ResolvedModule, error) {
+	paths := make([]string, 0, len(graph.Modules))
+	for path := range graph.Modules {
+		paths = append(paths, path)
+	}
+	sort.Slice(paths, func(i, j int) bool { return len(paths[i]) > len(paths[j]) })
+	for _, modulePath := range paths {
+		if !moduleContainsPackage(modulePath, importPath) {
+			continue
+		}
+		module := graph.Modules[modulePath]
+		root := module.Effective().Dir
+		if root == "" {
+			return "", ResolvedModule{}, fmt.Errorf("package target %q has no materialized module source", importPath)
+		}
+		suffix := strings.TrimPrefix(importPath, modulePath)
+		candidate := filepath.Join(root, filepath.FromSlash(strings.TrimPrefix(suffix, "/")))
+		dir, err := graph.files.canonicalDir(candidate)
+		if err != nil {
+			return "", ResolvedModule{}, fmt.Errorf("package target %q: %w", importPath, err)
+		}
+		if err := validatePackagePath(module, importPath, dir); err != nil {
+			return "", ResolvedModule{}, err
+		}
+		// Overlay-only packages have no physical cwd; the graph owns their identity.
+		if graph.files != nil && graph.files.hasReplacementChild(dir) {
+			return dir, module, nil
+		}
+		if err := validatePackageOwnership(ctx, policy, module, importPath, dir); err != nil {
+			return "", ResolvedModule{}, err
+		}
+		return dir, module, nil
+	}
+	return "", ResolvedModule{}, fmt.Errorf("package target %q is outside the effective module graph", importPath)
+}
+
+// retargetEffectiveGraph keeps the caller graph and changes only its target module.
+func retargetEffectiveGraph(ctx context.Context, graph *effectiveGraph, target ResolvedModule, policy GraphPolicy) (*effectiveGraph, error) {
+	modfilePath := target.Effective().GoMod
+	if target.Selected.Path == graph.Target.Selected.Path {
+		modfilePath = graph.TargetModFile.Path
+	}
+	identity, classPaths, err := readTargetModFileView(modfilePath, graph.files)
+	if err != nil {
+		return nil, err
+	}
+	classModules, err := materializeClassModules(ctx, graph.Target.Effective().Dir, policy, graph.Modules, classPaths)
+	if err != nil {
+		return nil, err
+	}
+	return &effectiveGraph{
+		Target:        target,
+		Modules:       graph.Modules,
+		ClassModules:  classModules,
+		TargetModFile: identity,
+		files:         graph.files,
+	}, nil
+}
+
+func moduleContainsPackage(modulePath, packagePath string) bool {
+	return packagePath == modulePath || strings.HasPrefix(packagePath, modulePath+"/")
+}

--- a/cmd/internal/projectdriver/graph_paths.go
+++ b/cmd/internal/projectdriver/graph_paths.go
@@ -1,0 +1,67 @@
+/*
+ * Copyright (c) 2026 The XGo Authors (xgo.dev). All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package projectdriver
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+func canonicalExistingDir(path string) (string, error) {
+	canonical, info, err := canonicalExistingInfo(path, os.Stat)
+	if err != nil {
+		return "", err
+	}
+	if !info.IsDir() {
+		return "", fmt.Errorf("%q is not a directory", path)
+	}
+	return canonical, nil
+}
+
+func canonicalExistingFile(path string) (string, error) {
+	canonical, info, err := canonicalExistingInfo(path, os.Lstat)
+	if err != nil {
+		return "", err
+	}
+	if info.Mode()&os.ModeSymlink != 0 || !info.Mode().IsRegular() {
+		return "", fmt.Errorf("%q is not a regular non-symlink file", path)
+	}
+	return canonical, nil
+}
+
+func canonicalExistingInfo(path string, stat func(string) (os.FileInfo, error)) (string, os.FileInfo, error) {
+	abs, err := filepath.Abs(path)
+	if err != nil {
+		return "", nil, err
+	}
+	canonical, err := filepath.EvalSymlinks(filepath.Clean(abs))
+	if err != nil {
+		return "", nil, err
+	}
+	info, err := stat(canonical)
+	if err != nil {
+		return "", nil, err
+	}
+	return canonical, info, nil
+}
+
+func pathWithin(root, path string) bool {
+	rel, err := filepath.Rel(root, path)
+	return err == nil && rel != ".." && !strings.HasPrefix(rel, ".."+string(filepath.Separator)) && !filepath.IsAbs(rel)
+}

--- a/cmd/internal/projectdriver/graph_paths_test.go
+++ b/cmd/internal/projectdriver/graph_paths_test.go
@@ -1,0 +1,97 @@
+/*
+ * Copyright (c) 2026 The XGo Authors (xgo.dev). All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package projectdriver
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+type canonicalPathTest struct {
+	name string
+	path string
+	kind func(string) (string, error)
+	want string
+}
+
+func TestCanonicalExistingPathKinds(t *testing.T) {
+	root := t.TempDir()
+	dir := filepath.Join(root, "dir")
+	file := filepath.Join(root, "file")
+	if err := os.Mkdir(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(file, []byte("data"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	wantDir, err := filepath.EvalSymlinks(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	wantFile, err := filepath.EvalSymlinks(file)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	tests := []canonicalPathTest{
+		{name: "directory", path: dir, kind: canonicalExistingDir, want: wantDir},
+		{name: "file", path: file, kind: canonicalExistingFile, want: wantFile},
+	}
+	if runtime.GOOS != "windows" {
+		dirLink := filepath.Join(root, "dir-link")
+		fileLink := filepath.Join(root, "file-link")
+		if err := os.Symlink(dir, dirLink); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.Symlink(file, fileLink); err != nil {
+			t.Fatal(err)
+		}
+		tests = append(tests,
+			canonicalPathTest{name: "directory symlink", path: dirLink, kind: canonicalExistingDir, want: wantDir},
+			canonicalPathTest{name: "file symlink", path: fileLink, kind: canonicalExistingFile, want: wantFile},
+		)
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			got, err := test.kind(test.path)
+			if err != nil || got != test.want {
+				t.Fatalf("canonical path = %q, %v; want %q", got, err, test.want)
+			}
+		})
+	}
+}
+
+func TestCanonicalExistingPathKindErrors(t *testing.T) {
+	root := t.TempDir()
+	file := filepath.Join(root, "file")
+	dir := filepath.Join(root, "dir")
+	if err := os.WriteFile(file, []byte("data"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Mkdir(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := canonicalExistingDir(file); err == nil || !strings.Contains(err.Error(), "is not a directory") {
+		t.Fatalf("canonicalExistingDir(file) = %v", err)
+	}
+	if _, err := canonicalExistingFile(dir); err == nil || !strings.Contains(err.Error(), "is not a regular non-symlink file") {
+		t.Fatalf("canonicalExistingFile(dir) = %v", err)
+	}
+}

--- a/cmd/internal/projectdriver/graph_test.go
+++ b/cmd/internal/projectdriver/graph_test.go
@@ -1,0 +1,566 @@
+/*
+ * Copyright (c) 2026 The XGo Authors (xgo.dev). All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package projectdriver
+
+import (
+	"context"
+	"net/url"
+	"os"
+	"path/filepath"
+	"reflect"
+	"runtime"
+	"sort"
+	"strings"
+	"testing"
+)
+
+func TestGraphFileViewReadsOverlayReplacement(t *testing.T) {
+	root := t.TempDir()
+	logical := filepath.Join(root, "go.mod")
+	replacement := filepath.Join(root, "draft.mod")
+	mustWriteFile(t, logical, "module example.test/plain\n\ngo 1.25\n")
+	mustWriteFile(t, replacement, "module example.test/overlay\n\ngo 1.25\n")
+	overlay := mustOverlay(t, root, map[string]string{logical: replacement})
+	view, err := newGraphFileView(GraphPolicy{Overlay: overlay}, root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	got, err := view.readFile(logical)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(got), "module example.test/overlay") {
+		t.Fatalf("overlay read = %q", got)
+	}
+}
+
+func TestGraphFileViewSynthesizesOverlayParentDirectories(t *testing.T) {
+	root := t.TempDir()
+	actual := filepath.Join(root, "actual.foo")
+	logical := filepath.Join(root, "virtual", "nested", "main.foo")
+	mustWriteFile(t, actual, "overlay project\n")
+	overlay := mustOverlay(t, root, map[string]string{logical: actual})
+	view, err := newGraphFileView(GraphPolicy{Overlay: overlay}, root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	names, err := view.regularFileNames(filepath.Join(root, "virtual", "nested"))
+	if err != nil {
+		t.Fatalf("regularFileNames() = %v", err)
+	}
+	if !reflect.DeepEqual(names, []string{"main.foo"}) {
+		t.Fatalf("regularFileNames() = %#v, want [main.foo]", names)
+	}
+	dir, err := view.canonicalDir(filepath.Join(root, "virtual", "nested"))
+	if err != nil || dir != filepath.Join(root, "virtual", "nested") {
+		t.Fatalf("canonicalDir() = %q, %v", dir, err)
+	}
+}
+
+func TestGraphFileViewDeletedParentAllowsAddedChild(t *testing.T) {
+	root := t.TempDir()
+	parent := filepath.Join(root, "parent")
+	hidden := filepath.Join(parent, "physical")
+	actual := filepath.Join(root, "replacement.foo")
+	logical := filepath.Join(parent, "child", "main.foo")
+	mustMkdirAll(t, hidden)
+	mustWriteFile(t, filepath.Join(parent, "old.foo"), "old\n")
+	mustWriteFile(t, actual, "new\n")
+	overlay := mustOverlay(t, root, map[string]string{parent: "", logical: actual})
+	view, err := newGraphFileView(GraphPolicy{Overlay: overlay}, root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	got, err := view.readFile(logical)
+	if err != nil || string(got) != "new\n" {
+		t.Fatalf("readFile() = %q, %v", got, err)
+	}
+	names, err := view.regularFileNames(filepath.Join(parent, "child"))
+	if err != nil {
+		t.Fatalf("regularFileNames() = %v", err)
+	}
+	if !reflect.DeepEqual(names, []string{"main.foo"}) {
+		t.Fatalf("regularFileNames() = %#v, want [main.foo]", names)
+	}
+	if visible, err := view.directoryVisible(hidden); err != nil || visible {
+		t.Fatalf("deleted physical child visibility = %t, %v", visible, err)
+	}
+}
+
+func TestGraphFileViewDoesNotInspectReplacementDestinations(t *testing.T) {
+	root := t.TempDir()
+	project := filepath.Join(root, "project")
+	mustMkdirAll(t, project)
+	missing := filepath.Join(root, "missing.foo")
+	directory := filepath.Join(root, "replacement-dir")
+	mustMkdirAll(t, directory)
+	replacements := map[string]string{
+		filepath.Join(project, "missing.foo"):   missing,
+		filepath.Join(project, "directory.foo"): directory,
+	}
+	if runtime.GOOS != "windows" {
+		target := filepath.Join(root, "target.foo")
+		mustWriteFile(t, target, "target\n")
+		symlink := filepath.Join(root, "symlink.foo")
+		if err := os.Symlink(target, symlink); err != nil {
+			t.Fatal(err)
+		}
+		replacements[filepath.Join(project, "symlink.foo")] = symlink
+	}
+	overlay := mustOverlay(t, root, replacements)
+	view, err := newGraphFileView(GraphPolicy{Overlay: overlay}, root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	names, err := view.regularFileNames(project)
+	if err != nil {
+		t.Fatalf("regularFileNames() = %v", err)
+	}
+	want := []string{"directory.foo", "missing.foo"}
+	if runtime.GOOS != "windows" {
+		want = append(want, "symlink.foo")
+	}
+	sort.Strings(want)
+	if !reflect.DeepEqual(names, want) {
+		t.Fatalf("regularFileNames() = %#v, want %#v", names, want)
+	}
+}
+
+func TestGraphFileViewAnchorsRelativeDirectoryNames(t *testing.T) {
+	root := t.TempDir()
+	mustMkdirAll(t, filepath.Join(root, "project", "game"))
+	view, err := newGraphFileView(GraphPolicy{}, root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	names, err := view.directoryNames("project")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !reflect.DeepEqual(names, []string{"game"}) {
+		t.Fatalf("directoryNames() = %#v, want [game]", names)
+	}
+}
+
+func TestGraphEnvironmentNeutralizesAmbientGOFLAGS(t *testing.T) {
+	base := []string{"GOFLAGS=-tags=ambient", "GOWORK=/old/work", "PATH=/bin"}
+	env := graphEnvironment(base, "off")
+	if got, ok := environmentValue(env, "GOFLAGS"); !ok || got != neutralGOFLAGS {
+		t.Fatalf("GOFLAGS = %q, %t; want %q", got, ok, neutralGOFLAGS)
+	}
+	if got, ok := environmentValue(env, "GOWORK"); !ok || got != "off" {
+		t.Fatalf("GOWORK = %q, %t; want off", got, ok)
+	}
+}
+
+func TestPreparePoliciesReadsPersistedGOFLAGS(t *testing.T) {
+	if testing.Short() {
+		t.Skip("invokes the host Go command")
+	}
+	dir := t.TempDir()
+	goEnv := filepath.Join(t.TempDir(), "go.env")
+	mustWriteFile(t, goEnv, "GOFLAGS=-buildvcs=false\n")
+	t.Setenv("GOENV", goEnv)
+	t.Setenv("GOWORK", "off")
+	for _, state := range []string{"empty", "unset"} {
+		t.Run(state, func(t *testing.T) {
+			if state == "empty" {
+				t.Setenv("GOFLAGS", "")
+			} else {
+				unsetTestEnv(t, "GOFLAGS")
+			}
+			policy, err := preparePolicies(context.Background(), dir, nil)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if !policy.build.DisableBuildVCS {
+				t.Fatalf("build policy = %#v; persisted GOFLAGS was ignored", policy.build)
+			}
+		})
+	}
+}
+
+func TestGraphEnvironmentMasksPersistedGOFLAGS(t *testing.T) {
+	if testing.Short() {
+		t.Skip("invokes the host Go command")
+	}
+	dir := t.TempDir()
+	goEnv := filepath.Join(t.TempDir(), "go.env")
+	mustWriteFile(t, goEnv, "GOFLAGS=-modfile=missing.mod\n")
+	t.Setenv("GOENV", goEnv)
+	t.Setenv("GOFLAGS", "")
+	goCommand, err := hostGoCommand()
+	if err != nil {
+		t.Fatal(err)
+	}
+	got, err := goEnvValueWithEnvironment(context.Background(), goCommand, dir, "GOFLAGS", graphEnvironment(os.Environ(), "off"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != neutralGOFLAGS {
+		t.Fatalf("effective GOFLAGS = %q, want %q", got, neutralGOFLAGS)
+	}
+}
+
+func TestReadTargetModFileViewAllowsOverlayOnlyModfile(t *testing.T) {
+	root := t.TempDir()
+	logical := filepath.Join(root, "go.mod")
+	actual := filepath.Join(root, "overlay.mod")
+	mustWriteFile(t, actual, "module example.test/overlay\n\ngo 1.25\n")
+	overlay := mustOverlay(t, root, map[string]string{logical: actual})
+	view, err := newGraphFileView(GraphPolicy{Overlay: overlay}, root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	identity, classes, err := readTargetModFileView(logical, view)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if identity.Path != logical || len(identity.SHA256) != 64 || len(classes) != 0 {
+		t.Fatalf("overlay-only modfile = %#v, classes %#v", identity, classes)
+	}
+}
+
+func TestSelectTargetModuleUsesUniqueDeepestOwner(t *testing.T) {
+	root := t.TempDir()
+	nested := filepath.Join(root, "nested")
+	project := filepath.Join(nested, "game")
+	modules := map[string]ResolvedModule{
+		"example.test/outer-a": {Selected: ModuleRef{Path: "example.test/outer-a", Dir: root}},
+		"example.test/outer-b": {Selected: ModuleRef{Path: "example.test/outer-b", Dir: root}},
+		"example.test/nested":  {Selected: ModuleRef{Path: "example.test/nested", Dir: nested}},
+	}
+
+	got, err := selectTargetModule(project, modules)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Selected.Path != "example.test/nested" {
+		t.Fatalf("target module = %q, want example.test/nested", got.Selected.Path)
+	}
+}
+
+func TestSelectTargetModuleRejectsAmbiguousDeepestOwners(t *testing.T) {
+	root := t.TempDir()
+	nested := filepath.Join(root, "nested")
+	project := filepath.Join(nested, "game")
+	modules := map[string]ResolvedModule{
+		"example.test/outer":  {Selected: ModuleRef{Path: "example.test/outer", Dir: root}},
+		"example.test/second": {Selected: ModuleRef{Path: "example.test/second", Dir: nested}},
+		"example.test/first":  {Selected: ModuleRef{Path: "example.test/first", Dir: nested}},
+	}
+
+	_, err := selectTargetModule(project, modules)
+	want := "ambiguous effective module owners: example.test/first, example.test/second"
+	if err == nil || !strings.Contains(err.Error(), want) {
+		t.Fatalf("selectTargetModule() error = %v, want %q", err, want)
+	}
+}
+
+func TestLoadEffectiveGraphLocalReplace(t *testing.T) {
+	if testing.Short() {
+		t.Skip("invokes the host Go command")
+	}
+	t.Setenv("GOWORK", "off")
+	root := t.TempDir()
+	app := filepath.Join(root, "app")
+	framework := filepath.Join(root, "framework")
+	mustMkdirAll(t, filepath.Join(app, "game"))
+	mustMkdirAll(t, filepath.Join(framework, "cmd", "driver"))
+	mustWriteFile(t, filepath.Join(app, "go.mod"), `module example.test/app
+
+go 1.25
+
+require example.test/framework v1.2.3 //xgo:class
+
+replace example.test/framework => ../framework
+`)
+	mustModuleFile(t, filepath.Join(framework, "go.mod"), "example.test/framework")
+	mustWriteFile(t, filepath.Join(framework, "cmd", "driver", "main.go"), "package main\nfunc main() {}\n")
+
+	policy := mustPolicies(t, app)
+	graph := mustGraph(t, filepath.Join(app, "game"), policy.graph)
+	if got, want := graph.Target.Selected.Path, "example.test/app"; got != want {
+		t.Fatalf("target = %q, want %q", got, want)
+	}
+	origin := graph.Modules["example.test/framework"]
+	if !reflect.DeepEqual(graph.ClassModules, []ResolvedModule{origin}) {
+		t.Fatalf("resolved class modules = %#v", graph.ClassModules)
+	}
+	if origin.Selected.Version != "v1.2.3" || origin.Selected.Dir != "" || origin.Replace == nil {
+		t.Fatalf("replacement was flattened: %#v", origin)
+	}
+	framework, err := canonicalExistingDir(framework)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if origin.Replace.Dir != framework || origin.Replace.GoMod != filepath.Join(framework, "go.mod") {
+		t.Fatalf("replacement source = %#v", origin.Replace)
+	}
+	dir, module, err := resolvePackageDirectory(context.Background(), graph, "example.test/framework/cmd/driver", app, policy.graph)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if dir != filepath.Join(framework, "cmd", "driver") || module.Selected.Path != "example.test/framework" {
+		t.Fatalf("resolved package = %q, %#v", dir, module)
+	}
+}
+
+func TestResolvePackageDirectoryHonorsNestedModuleBoundary(t *testing.T) {
+	if testing.Short() {
+		t.Skip("invokes the host Go command")
+	}
+	t.Setenv("GOWORK", "off")
+	app := t.TempDir()
+	nested := filepath.Join(app, "nested")
+	mustMkdirAll(t, nested)
+	mustModuleFile(t, filepath.Join(app, "go.mod"), "example.test/app")
+	mustModuleFile(t, filepath.Join(nested, "go.mod"), "example.test/nested")
+	mustWriteFile(t, filepath.Join(nested, "main.go"), "package main\n")
+	policy := mustPolicies(t, app)
+	graph := mustGraph(t, app, policy.graph)
+	if _, _, err := resolvePackageDirectory(context.Background(), graph, "example.test/app/nested", app, policy.graph); err == nil {
+		t.Fatal("package path crossing a nested module boundary resolved successfully")
+	}
+}
+
+func TestSanitizeGraphFlagsPropagatesFilesystemErrors(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("self-referential symlink setup is not portable to Windows")
+	}
+	dir := t.TempDir()
+	path := filepath.Join(dir, "loop.mod")
+	if err := os.Symlink("loop.mod", path); err != nil {
+		t.Fatal(err)
+	}
+	policy := parsedFlags{graph: GraphPolicy{ModFile: path}}
+	if _, err := sanitizeGraphFlags(policy); err == nil {
+		t.Fatal("graph input I/O failure was treated as a missing file")
+	}
+}
+
+func TestLoadEffectiveGraphModfile(t *testing.T) {
+	if testing.Short() {
+		t.Skip("invokes the host Go command")
+	}
+	t.Setenv("GOWORK", "off")
+	dir := t.TempDir()
+	mustModuleFile(t, filepath.Join(dir, "go.mod"), "example.test/app")
+	mustModuleFile(t, filepath.Join(dir, "driver.mod"), "example.test/app")
+	policy := mustPolicies(t, dir, "-modfile=driver.mod")
+	graph := mustGraph(t, dir, policy.graph)
+	wantModfile, err := canonicalExistingFile(filepath.Join(dir, "driver.mod"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if graph.TargetModFile.Path != wantModfile {
+		t.Fatalf("target modfile = %q", graph.TargetModFile.Path)
+	}
+	owner, err := goModForDir(context.Background(), policy.graph, dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	wantOwner, err := canonicalExistingFile(filepath.Join(dir, "go.mod"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if owner != wantOwner {
+		t.Fatalf("owning go.mod = %q, want %q", owner, wantOwner)
+	}
+}
+
+func TestReadTargetModFileClassMarkerBoundaries(t *testing.T) {
+	dir := t.TempDir()
+	goMod := filepath.Join(dir, "go.mod")
+	mustWriteFile(t, goMod, `module example.test/app
+
+go 1.25
+
+require (
+	example.test/second v1.0.0 //gop:class payload
+	example.test/classroom v1.0.0 //xgo:classroom
+	example.test/first v1.0.0 // xgo:class
+)
+`)
+	identity, paths, err := readTargetModFile(goMod)
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := []string{"example.test/second", "example.test/first"}
+	if !reflect.DeepEqual(paths, want) {
+		t.Fatalf("class paths = %#v, want %#v", paths, want)
+	}
+	if identity.Path != canonicalFile(t, goMod) || len(identity.SHA256) != 64 {
+		t.Fatalf("identity = %#v", identity)
+	}
+}
+
+func TestToXGoGraphPreservesResolvedClassModuleOrder(t *testing.T) {
+	second := ResolvedModule{Selected: ModuleRef{Path: "example.test/second"}}
+	first := ResolvedModule{Selected: ModuleRef{Path: "example.test/first"}}
+	graph := &effectiveGraph{
+		Target:       ResolvedModule{Selected: ModuleRef{Path: "example.test/app"}},
+		Modules:      map[string]ResolvedModule{},
+		ClassModules: []ResolvedModule{second, first},
+	}
+	got := toXGoGraph(graph)
+	if len(got.ClassModules) != 2 || got.ClassModules[0].Selected.Path != "example.test/second" || got.ClassModules[1].Selected.Path != "example.test/first" {
+		t.Fatalf("ClassModules = %#v", got.ClassModules)
+	}
+}
+
+func TestRetargetEffectiveGraphPreservesClassModuleOrder(t *testing.T) {
+	root := t.TempDir()
+	app := filepath.Join(root, "app")
+	framework := filepath.Join(root, "framework")
+	firstDir := filepath.Join(root, "first")
+	secondDir := filepath.Join(root, "second")
+	for _, dir := range []string{app, framework, firstDir, secondDir} {
+		mustMkdirAll(t, dir)
+	}
+	appGoMod := filepath.Join(app, "go.mod")
+	frameworkGoMod := filepath.Join(framework, "go.mod")
+	firstGoMod := filepath.Join(firstDir, "go.mod")
+	secondGoMod := filepath.Join(secondDir, "go.mod")
+	mustModuleFile(t, appGoMod, "example.test/app")
+	mustWriteFile(t, frameworkGoMod, `module example.test/framework
+
+go 1.25
+
+require (
+	example.test/second v1.0.0 //xgo:class
+	example.test/first v1.0.0 //xgo:class
+)
+`)
+	mustModuleFile(t, firstGoMod, "example.test/first")
+	mustModuleFile(t, secondGoMod, "example.test/second")
+
+	appModule := ResolvedModule{Selected: ModuleRef{Path: "example.test/app", Dir: app, GoMod: appGoMod}, Main: true}
+	frameworkModule := ResolvedModule{Selected: ModuleRef{Path: "example.test/framework", Dir: framework, GoMod: frameworkGoMod}}
+	firstModule := ResolvedModule{Selected: ModuleRef{Path: "example.test/first", Dir: firstDir, GoMod: firstGoMod}}
+	secondModule := ResolvedModule{Selected: ModuleRef{Path: "example.test/second", Dir: secondDir, GoMod: secondGoMod}}
+	graph := &effectiveGraph{
+		Target: appModule,
+		Modules: map[string]ResolvedModule{
+			"example.test/app":       appModule,
+			"example.test/framework": frameworkModule,
+			"example.test/first":     firstModule,
+			"example.test/second":    secondModule,
+		},
+		TargetModFile: fileIdentity{Path: canonicalFile(t, appGoMod)},
+	}
+
+	retargeted, err := retargetEffectiveGraph(context.Background(), graph, frameworkModule, GraphPolicy{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := []ResolvedModule{secondModule, firstModule}
+	if !reflect.DeepEqual(retargeted.ClassModules, want) {
+		t.Fatalf("resolved class modules = %#v, want %#v", retargeted.ClassModules, want)
+	}
+	if retargeted.TargetModFile.Path != canonicalFile(t, frameworkGoMod) {
+		t.Fatalf("target modfile = %q", retargeted.TargetModFile.Path)
+	}
+}
+
+func TestRetargetEffectiveGraphMaterializesClassModules(t *testing.T) {
+	if testing.Short() {
+		t.Skip("invokes the host Go command")
+	}
+	root := t.TempDir()
+	proxy := t.TempDir()
+	cache := writableModuleCache(t)
+	app := filepath.Join(root, "app")
+	framework := filepath.Join(root, "framework")
+	mustMkdirAll(t, app)
+	mustMkdirAll(t, framework)
+	appGoMod := filepath.Join(app, "go.mod")
+	frameworkGoMod := filepath.Join(framework, "go.mod")
+	mustModuleFile(t, appGoMod, "example.test/app")
+	mustWriteFile(t, frameworkGoMod, `module example.test/framework
+
+go 1.25
+
+require example.test/class v1.0.0 //xgo:class
+`)
+	writeModuleProxy(t, proxy, "example.test/class", map[string]map[string]string{
+		"v1.0.0": {"go.mod": "module example.test/class\n\ngo 1.25\n"},
+	})
+	t.Setenv("GOMODCACHE", cache)
+	t.Setenv("GOPROXY", (&url.URL{Scheme: "file", Path: filepath.ToSlash(proxy)}).String())
+	t.Setenv("GOSUMDB", "off")
+	t.Setenv("GOWORK", "off")
+
+	appModule := ResolvedModule{Selected: ModuleRef{Path: "example.test/app", Dir: app, GoMod: appGoMod}, Main: true}
+	frameworkModule := ResolvedModule{Selected: ModuleRef{Path: "example.test/framework", Dir: framework, GoMod: frameworkGoMod}}
+	classModule := ResolvedModule{Selected: ModuleRef{Path: "example.test/class", Version: "v1.0.0"}}
+	view, err := newGraphFileView(GraphPolicy{}, app)
+	if err != nil {
+		t.Fatal(err)
+	}
+	graph := &effectiveGraph{
+		Target: appModule,
+		Modules: map[string]ResolvedModule{
+			"example.test/app":       appModule,
+			"example.test/framework": frameworkModule,
+			"example.test/class":     classModule,
+		},
+		TargetModFile: fileIdentity{Path: canonicalFile(t, appGoMod)},
+		files:         view,
+	}
+	goCommand, err := hostGoCommand()
+	if err != nil {
+		t.Fatal(err)
+	}
+	policy := GraphPolicy{GoCommand: goCommand, GoWork: "off", ModMode: modModeReadonly, WorkDir: app}
+	retargeted, err := retargetEffectiveGraph(context.Background(), graph, frameworkModule, policy)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(retargeted.ClassModules) != 1 || retargeted.ClassModules[0].Effective().Dir == "" {
+		t.Fatalf("class modules = %#v", retargeted.ClassModules)
+	}
+	if graph.Modules["example.test/class"].Effective().Dir == "" {
+		t.Fatal("materialized class module was not retained in the graph")
+	}
+}
+
+func TestPreparePoliciesIgnoresXGoGoCmd(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("shell fixture")
+	}
+	t.Setenv("XGO_GOCMD", filepath.Join(t.TempDir(), "does-not-exist"))
+	t.Setenv("GOWORK", "off")
+	policy := mustPolicies(t, t.TempDir())
+	if filepath.Base(policy.graph.GoCommand) != "go" {
+		t.Fatalf("Go command = %q", policy.graph.GoCommand)
+	}
+}
+
+func TestNormalizeListedModuleUsesResolvedValidation(t *testing.T) {
+	root := t.TempDir()
+	dir := filepath.Join(root, "source")
+	mustMkdirAll(t, dir)
+	goMod := filepath.Join(root, "external.mod")
+	mustWriteFile(t, goMod, "module example.test/mod\n")
+	_, err := normalizeListedModule(goListModule{
+		Path: "example.test/mod", Version: "v1.2.3", Dir: dir, GoMod: goMod,
+	})
+	if err == nil || !strings.Contains(err.Error(), "matching Go module-cache metadata") {
+		t.Fatalf("validation error = %v", err)
+	}
+}

--- a/cmd/internal/projectdriver/output_test.go
+++ b/cmd/internal/projectdriver/output_test.go
@@ -1,0 +1,386 @@
+/*
+ * Copyright (c) 2026 The XGo Authors (xgo.dev). All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package projectdriver
+
+import (
+	"context"
+	"errors"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"testing"
+)
+
+func TestOutputTransactionCommit(t *testing.T) {
+	dir := t.TempDir()
+	final := filepath.Join(dir, "game")
+	if runtime.GOOS == "windows" {
+		final += ".exe"
+	}
+	if err := os.WriteFile(final, []byte("old"), 0755); err != nil {
+		t.Fatal(err)
+	}
+	tx, err := beginOutputTransaction(final, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	writeTestExecutable(t, tx.staged)
+	if err := tx.commitContext(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	got, err := os.ReadFile(final)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got) == 0 {
+		t.Fatal("final is empty")
+	}
+	if _, err := os.Stat(tx.dir); !os.IsNotExist(err) {
+		t.Fatalf("staging remains: %v", err)
+	}
+}
+
+func TestOutputTransactionCreatesMissingParents(t *testing.T) {
+	dir := t.TempDir()
+	parent := filepath.Join(dir, "dist", "bin")
+	final := filepath.Join(parent, "game")
+	if runtime.GOOS == "windows" {
+		final += ".exe"
+	}
+	tx, err := beginOutputTransaction(final, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer tx.abort()
+	writeTestExecutable(t, tx.staged)
+	if err := tx.commitContext(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	if info, err := os.Stat(final); err != nil || info.Size() == 0 {
+		t.Fatalf("nested output = %#v, %v", info, err)
+	}
+}
+
+func writeTestExecutable(t *testing.T, target string) {
+	t.Helper()
+	self, err := os.Executable()
+	if err != nil {
+		t.Fatal(err)
+	}
+	data, err := os.ReadFile(self)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(target, data, 0755); err != nil {
+		t.Fatal(err)
+	}
+	if runtime.GOOS == "darwin" {
+		if output, err := exec.Command("/usr/bin/codesign", "--force", "--sign", "-", target).CombinedOutput(); err != nil {
+			t.Fatalf("sign test executable: %v: %s", err, output)
+		}
+	}
+}
+
+func TestOutputTransactionFailurePreservesFinal(t *testing.T) {
+	dir := t.TempDir()
+	final := filepath.Join(dir, "game")
+	if err := os.WriteFile(final, []byte("old"), 0755); err != nil {
+		t.Fatal(err)
+	}
+	tx, err := beginOutputTransaction(final, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer tx.abort()
+	if err := os.WriteFile(tx.staged, nil, 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := tx.commitContext(context.Background()); err == nil {
+		t.Fatal("empty staged output committed")
+	}
+	tx.abort()
+	got, err := os.ReadFile(final)
+	if err != nil || string(got) != "old" {
+		t.Fatalf("final changed: %q, %v", got, err)
+	}
+	if _, err := os.Stat(tx.dir); !os.IsNotExist(err) {
+		t.Fatalf("failed transaction left staging directory: %v", err)
+	}
+}
+
+func TestCanceledBuildDoesNotCommitOutput(t *testing.T) {
+	dir := t.TempDir()
+	final := filepath.Join(dir, executableName("game"))
+	if err := os.WriteFile(final, []byte("old"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	tx, err := beginOutputTransaction(final, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer tx.abort()
+	writeTestExecutable(t, tx.staged)
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	if err := tx.commitContext(ctx); !errors.Is(err, context.Canceled) {
+		t.Fatalf("commitContext() = %v, want context cancellation", err)
+	}
+	got, err := os.ReadFile(final)
+	if err != nil || string(got) != "old" {
+		t.Fatalf("canceled commit changed final output: %q, %v", got, err)
+	}
+}
+
+func TestOutputTransactionRejectsSymlinkFinalAndCleansExtras(t *testing.T) {
+	dir := t.TempDir()
+	if runtime.GOOS != "windows" {
+		target := filepath.Join(dir, "target")
+		if err := os.WriteFile(target, []byte("old"), 0755); err != nil {
+			t.Fatal(err)
+		}
+		link := filepath.Join(dir, "link")
+		if err := os.Symlink(target, link); err != nil {
+			t.Fatal(err)
+		}
+		if _, err := beginOutputTransaction(link, false); err == nil {
+			t.Fatal("symlink final accepted")
+		}
+	}
+
+	final := filepath.Join(dir, "game")
+	if runtime.GOOS == "windows" {
+		final += ".exe"
+	}
+	tx, err := beginOutputTransaction(final, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer tx.abort()
+	writeTestExecutable(t, tx.staged)
+	if err := os.WriteFile(filepath.Join(tx.dir, "extra"), []byte("extra"), 0600); err != nil {
+		t.Fatal(err)
+	}
+	if err := tx.commitContext(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := os.Stat(final); err != nil {
+		t.Fatalf("final output: %v", err)
+	}
+	if _, err := os.Stat(tx.dir); !os.IsNotExist(err) {
+		t.Fatalf("staging remains: %v", err)
+	}
+}
+
+func TestOutputTransactionRejectsFinalSymlinkCreatedAfterBegin(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("symlink privileges vary on Windows")
+	}
+	dir := t.TempDir()
+	final := filepath.Join(dir, "game")
+	tx, err := beginOutputTransaction(final, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer tx.abort()
+	writeTestExecutable(t, tx.staged)
+	target := filepath.Join(dir, "target")
+	if err := os.WriteFile(target, []byte("target"), 0600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(target, final); err != nil {
+		t.Fatal(err)
+	}
+	if err := tx.commitContext(context.Background()); err == nil {
+		t.Fatal("final symlink created after begin was accepted")
+	}
+	if got, err := os.ReadFile(target); err != nil || string(got) != "target" {
+		t.Fatalf("symlink target changed: %q, %v", got, err)
+	}
+}
+
+func TestOutputTransactionPinsParentAcrossPathSwap(t *testing.T) {
+	base := t.TempDir()
+	parent := filepath.Join(base, "out")
+	if err := os.Mkdir(parent, 0700); err != nil {
+		t.Fatal(err)
+	}
+	final := filepath.Join(parent, "game")
+	if runtime.GOOS == "windows" {
+		final += ".exe"
+	}
+	if err := os.WriteFile(final, []byte("old"), 0755); err != nil {
+		t.Fatal(err)
+	}
+	tx, err := beginOutputTransaction(final, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer tx.abort()
+	writeTestExecutable(t, tx.staged)
+
+	moved := filepath.Join(base, "moved")
+	if err := os.Rename(parent, moved); err != nil {
+		t.Skipf("platform/filesystem cannot rename an open pinned directory: %v", err)
+	}
+	if err := os.Mkdir(parent, 0700); err != nil {
+		t.Fatal(err)
+	}
+	replacementFinal := filepath.Join(parent, filepath.Base(final))
+	if err := os.WriteFile(replacementFinal, []byte("replacement"), 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	commitErr := tx.commitContext(context.Background())
+	if commitErr == nil {
+		t.Fatal("commit accepted a replaced output parent pathname")
+	}
+	if got, err := os.ReadFile(replacementFinal); err != nil || string(got) != "replacement" {
+		t.Fatalf("replacement parent was modified: %q, %v", got, err)
+	}
+	movedFinal := filepath.Join(moved, filepath.Base(final))
+	got, err := os.ReadFile(movedFinal)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(got) != "old" {
+		t.Fatalf("failed commit changed pinned output: %q (%v)", got, commitErr)
+	}
+}
+
+func TestOutputTransactionRejectsWorkDirectorySwap(t *testing.T) {
+	dir := t.TempDir()
+	final := filepath.Join(dir, "game")
+	if runtime.GOOS == "windows" {
+		final += ".exe"
+	}
+	tx, err := beginOutputTransaction(final, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer tx.abort()
+	moved := tx.dir + ".moved"
+	if err := os.Rename(tx.dir, moved); err != nil {
+		t.Skipf("platform/filesystem cannot rename an open work directory: %v", err)
+	}
+	if err := os.Mkdir(tx.dir, 0700); err != nil {
+		t.Fatal(err)
+	}
+	sentinel := filepath.Join(tx.dir, "sentinel")
+	if err := os.WriteFile(sentinel, []byte("keep"), 0600); err != nil {
+		t.Fatal(err)
+	}
+	writeTestExecutable(t, tx.staged)
+	if err := tx.commitContext(context.Background()); err == nil {
+		t.Fatal("replaced work directory was accepted")
+	}
+	tx.abort()
+	if data, err := os.ReadFile(sentinel); err != nil || string(data) != "keep" {
+		t.Fatalf("replacement work directory was removed: %q, %v", data, err)
+	}
+	if _, err := os.Stat(final); !os.IsNotExist(err) {
+		t.Fatalf("failed work-directory transaction published output: %v", err)
+	}
+}
+
+func TestOutputTransactionSupportsStableParentAlias(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("symlink privileges vary on Windows")
+	}
+	base := t.TempDir()
+	parent := filepath.Join(base, "real")
+	if err := os.Mkdir(parent, 0700); err != nil {
+		t.Fatal(err)
+	}
+	alias := filepath.Join(base, "alias")
+	if err := os.Symlink(parent, alias); err != nil {
+		t.Fatal(err)
+	}
+	tx, err := beginOutputTransaction(filepath.Join(alias, "game"), false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer tx.abort()
+	writeTestExecutable(t, tx.staged)
+	if err := tx.commitContext(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	if info, err := os.Stat(filepath.Join(parent, "game")); err != nil || info.Size() == 0 {
+		t.Fatalf("aliased output = %#v, %v", info, err)
+	}
+}
+
+func TestOutputTransactionWindowsCaseAlias(t *testing.T) {
+	if runtime.GOOS != "windows" {
+		t.Skip("Windows case-insensitive output semantics")
+	}
+	dir := t.TempDir()
+	existing := filepath.Join(dir, "game.exe")
+	if err := os.WriteFile(existing, []byte("old"), 0755); err != nil {
+		t.Fatal(err)
+	}
+	tx, err := beginOutputTransaction(filepath.Join(dir, "GAME.EXE"), false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer tx.abort()
+	writeTestExecutable(t, tx.staged)
+	if err := tx.commitContext(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	info, err := os.Stat(existing)
+	if err != nil || info.Size() <= int64(len("old")) {
+		t.Fatalf("case-aliased output = %#v, %v", info, err)
+	}
+}
+
+func TestResolveBuildOutput(t *testing.T) {
+	dir := t.TempDir()
+	got, err := resolveBuildOutput(dir, "", "game")
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := filepath.Join(dir, executableName("game"))
+	if got != want {
+		t.Fatalf("output = %q, want %q", got, want)
+	}
+	got, err = resolveBuildOutput(dir, dir+string(filepath.Separator), "game")
+	if err != nil || got != want {
+		t.Fatalf("directory output = %q, %v", got, err)
+	}
+
+	got, err = resolveBuildOutput(dir, "relative/bin/game", "default")
+	want = filepath.Join(dir, "relative", "bin", "game")
+	if err != nil || got != want {
+		t.Fatalf("relative output = %q, %v; want %q", got, err, want)
+	}
+	got, err = resolveBuildOutput(dir, "custom.bin", "default")
+	want = filepath.Join(dir, "custom.bin")
+	if err != nil || got != want {
+		t.Fatalf("explicit output = %q, %v; want %q", got, err, want)
+	}
+
+	relativeDir := filepath.Join(dir, "relative-dir")
+	if err := os.Mkdir(relativeDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	got, err = resolveBuildOutput(dir, filepath.Join("relative-dir", ""), "default")
+	want = filepath.Join(relativeDir, executableName("default"))
+	if err != nil || got != want {
+		t.Fatalf("relative directory output = %q, %v; want %q", got, err, want)
+	}
+}

--- a/cmd/internal/projectdriver/output_transaction.go
+++ b/cmd/internal/projectdriver/output_transaction.go
@@ -1,0 +1,321 @@
+/*
+ * Copyright (c) 2026 The XGo Authors (xgo.dev). All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package projectdriver
+
+import (
+	"context"
+	"crypto/rand"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+)
+
+func resolveBuildOutput(cwd, requested, defaultName string) (string, error) {
+	if defaultName == "" {
+		return "", fmt.Errorf("empty driver executable name")
+	}
+	defaultName = executableName(defaultName)
+	path := requested
+	if path == "" {
+		path = filepath.Join(cwd, defaultName)
+	} else {
+		trailingSeparator := strings.HasSuffix(path, string(filepath.Separator)) ||
+			(runtime.GOOS == "windows" && strings.HasSuffix(path, "/"))
+		if !filepath.IsAbs(path) {
+			path = filepath.Join(cwd, path)
+		}
+		info, err := os.Stat(path)
+		if trailingSeparator || (err == nil && info.IsDir()) {
+			path = filepath.Join(path, defaultName)
+		}
+	}
+	abs, err := filepath.Abs(path)
+	if err != nil {
+		return "", err
+	}
+	return filepath.Clean(abs), nil
+}
+
+func executableName(path string) string {
+	if runtime.GOOS == "windows" && !strings.EqualFold(filepath.Ext(path), ".exe") {
+		return path + ".exe"
+	}
+	return path
+}
+
+type outputTransaction struct {
+	final        string
+	parentPath   string
+	dir          string
+	staged       string
+	parent       *os.Root
+	finalName    string
+	workName     string
+	stagedName   string
+	workIdentity os.FileInfo
+	keepDir      bool
+	closed       bool
+}
+
+func beginOutputTransaction(final string, keepWork bool) (*outputTransaction, error) {
+	parent := filepath.Dir(final)
+	// Match go build -o semantics; 0o777 still honors the caller's umask.
+	if err := os.MkdirAll(parent, 0o777); err != nil {
+		return nil, fmt.Errorf("create driver output parent %q: %w", parent, err)
+	}
+	root, err := openPinnedOutputParent(parent)
+	if err != nil {
+		return nil, err
+	}
+	finalName := filepath.Base(final)
+	if err := validateExistingFinal(root, finalName, final); err != nil {
+		_ = root.Close()
+		return nil, err
+	}
+	workName, err := createOutputWorkDir(root)
+	if err != nil {
+		_ = root.Close()
+		return nil, err
+	}
+	workIdentity, err := root.Lstat(workName)
+	if err != nil {
+		_ = root.RemoveAll(workName)
+		_ = root.Close()
+		return nil, fmt.Errorf("inspect driver output work directory: %w", err)
+	}
+	stagedName := filepath.Join(workName, finalName)
+	return &outputTransaction{
+		final:        final,
+		parentPath:   parent,
+		dir:          filepath.Join(parent, workName),
+		staged:       filepath.Join(parent, stagedName),
+		parent:       root,
+		finalName:    finalName,
+		workName:     workName,
+		stagedName:   stagedName,
+		workIdentity: workIdentity,
+		keepDir:      keepWork,
+	}, nil
+}
+
+func openPinnedOutputParent(parent string) (*os.Root, error) {
+	before, err := os.Stat(parent)
+	if err != nil {
+		return nil, fmt.Errorf("driver output parent: %w", err)
+	}
+	if !before.IsDir() {
+		return nil, fmt.Errorf("driver output parent %q is not a directory", parent)
+	}
+	root, err := os.OpenRoot(parent)
+	if err != nil {
+		return nil, fmt.Errorf("open driver output parent: %w", err)
+	}
+	pinned, err := root.Stat(".")
+	if err != nil {
+		_ = root.Close()
+		return nil, fmt.Errorf("inspect pinned driver output parent: %w", err)
+	}
+	after, err := os.Stat(parent)
+	if err != nil {
+		_ = root.Close()
+		return nil, fmt.Errorf("revalidate driver output parent: %w", err)
+	}
+	if !os.SameFile(before, pinned) || !os.SameFile(pinned, after) {
+		_ = root.Close()
+		return nil, fmt.Errorf("driver output parent %q changed while it was opened", parent)
+	}
+	return root, nil
+}
+
+func createOutputWorkDir(root *os.Root) (string, error) {
+	var random [12]byte
+	for range 16 {
+		if _, err := rand.Read(random[:]); err != nil {
+			return "", fmt.Errorf("generate driver output work directory: %w", err)
+		}
+		name := ".xgo-driver-output-" + hex.EncodeToString(random[:])
+		if err := root.Mkdir(name, 0700); err == nil {
+			return name, nil
+		} else if !errors.Is(err, fs.ErrExist) {
+			return "", fmt.Errorf("create driver output work directory: %w", err)
+		}
+	}
+	return "", fmt.Errorf("create driver output work directory: too many name collisions")
+}
+
+func validateExistingFinal(root *os.Root, name, displayPath string) error {
+	info, err := root.Lstat(name)
+	if errors.Is(err, fs.ErrNotExist) {
+		return nil
+	}
+	if err != nil {
+		return fmt.Errorf("inspect driver output %q: %w", displayPath, err)
+	}
+	if info.Mode()&os.ModeSymlink != 0 {
+		return fmt.Errorf("driver output %q is a symlink", displayPath)
+	}
+	if !info.Mode().IsRegular() {
+		return fmt.Errorf("driver output %q is not a regular file", displayPath)
+	}
+	return nil
+}
+
+func (tx *outputTransaction) commitContext(ctx context.Context) error {
+	if tx == nil || tx.closed {
+		return fmt.Errorf("driver output transaction is closed")
+	}
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	if cause := context.Cause(ctx); cause != nil {
+		return cause
+	}
+	if err := tx.checkParentPath(); err != nil {
+		return err
+	}
+	currentInfo, err := tx.validateStagedOutput()
+	if err != nil {
+		return err
+	}
+	if err := validateExistingFinal(tx.parent, tx.finalName, tx.final); err != nil {
+		return err
+	}
+	if finalInfo, err := tx.parent.Lstat(tx.finalName); err == nil && os.SameFile(currentInfo, finalInfo) {
+		return fmt.Errorf("driver output aliases existing final output")
+	} else if err != nil && !errors.Is(err, fs.ErrNotExist) {
+		return fmt.Errorf("reinspect driver output %q: %w", tx.final, err)
+	}
+	if err := tx.checkParentPath(); err != nil {
+		return err
+	}
+	if cause := context.Cause(ctx); cause != nil {
+		return cause
+	}
+	if err := tx.parent.Rename(tx.stagedName, tx.finalName); err != nil {
+		state := "absent"
+		if info, statErr := tx.parent.Lstat(tx.finalName); statErr == nil {
+			state = info.Mode().String()
+		} else if !errors.Is(statErr, fs.ErrNotExist) {
+			state = statErr.Error()
+		}
+		return fmt.Errorf("commit driver output (final state %s): %w", state, err)
+	}
+	if !tx.keepDir {
+		_ = tx.parent.RemoveAll(tx.workName)
+	}
+	syncOutputParent(tx.parent)
+	tx.closed = true
+	_ = tx.parent.Close()
+	return nil
+}
+
+func (tx *outputTransaction) validateStagedOutput() (os.FileInfo, error) {
+	workInfo, err := tx.parent.Lstat(tx.workName)
+	if err != nil {
+		return nil, fmt.Errorf("inspect driver output work directory: %w", err)
+	}
+	if workInfo.Mode()&os.ModeSymlink != 0 || !workInfo.IsDir() || !os.SameFile(workInfo, tx.workIdentity) {
+		return nil, fmt.Errorf("driver output work directory changed during driver execution")
+	}
+	info, err := tx.parent.Lstat(tx.stagedName)
+	if err != nil {
+		return nil, fmt.Errorf("driver output: %w", err)
+	}
+	if info.Mode()&os.ModeSymlink != 0 || !info.Mode().IsRegular() {
+		return nil, fmt.Errorf("driver output %q is not a regular non-symlink file", tx.staged)
+	}
+	if info.Size() == 0 {
+		return nil, fmt.Errorf("driver output %q is empty", tx.staged)
+	}
+	if runtime.GOOS != "windows" && info.Mode().Perm()&0111 == 0 {
+		return nil, fmt.Errorf("driver output %q is not executable", tx.staged)
+	}
+	file, err := tx.parent.Open(tx.stagedName)
+	if err != nil {
+		return nil, fmt.Errorf("open driver output: %w", err)
+	}
+	openedInfo, err := file.Stat()
+	if err != nil {
+		_ = file.Close()
+		return nil, fmt.Errorf("inspect open driver output: %w", err)
+	}
+	if !os.SameFile(info, openedInfo) || !openedInfo.Mode().IsRegular() {
+		_ = file.Close()
+		return nil, fmt.Errorf("driver output changed while it was opened")
+	}
+	// Windows and AIX cannot flush this read-only validation handle.
+	if runtime.GOOS != "windows" && runtime.GOOS != "aix" {
+		if err := file.Sync(); err != nil {
+			_ = file.Close()
+			return nil, fmt.Errorf("sync driver output: %w", err)
+		}
+	}
+	if err := validateHostExecutable(file, tx.staged); err != nil {
+		_ = file.Close()
+		return nil, err
+	}
+	if err := file.Close(); err != nil {
+		return nil, fmt.Errorf("close driver output: %w", err)
+	}
+	currentInfo, err := tx.parent.Lstat(tx.stagedName)
+	if err != nil || !os.SameFile(openedInfo, currentInfo) {
+		return nil, fmt.Errorf("driver output changed after validation")
+	}
+	return currentInfo, nil
+}
+
+func (tx *outputTransaction) checkParentPath() error {
+	pinned, err := tx.parent.Stat(".")
+	if err != nil {
+		return fmt.Errorf("inspect pinned driver output parent: %w", err)
+	}
+	current, err := os.Stat(tx.parentPath)
+	if err != nil {
+		return fmt.Errorf("revalidate driver output parent %q: %w", tx.parentPath, err)
+	}
+	if !current.IsDir() || !os.SameFile(pinned, current) {
+		return fmt.Errorf("driver output parent %q changed during driver execution", tx.parentPath)
+	}
+	return nil
+}
+
+func syncOutputParent(root *os.Root) {
+	dir, err := root.Open(".")
+	if err != nil {
+		return
+	}
+	_ = dir.Sync()
+	_ = dir.Close()
+}
+
+func (tx *outputTransaction) abort() {
+	if tx == nil || tx.closed {
+		return
+	}
+	if !tx.keepDir {
+		if info, err := tx.parent.Lstat(tx.workName); err == nil && info.IsDir() && info.Mode()&os.ModeSymlink == 0 && os.SameFile(info, tx.workIdentity) {
+			_ = tx.parent.RemoveAll(tx.workName)
+		}
+	}
+	tx.closed = true
+	_ = tx.parent.Close()
+}

--- a/cmd/internal/projectdriver/process_other.go
+++ b/cmd/internal/projectdriver/process_other.go
@@ -1,0 +1,43 @@
+//go:build !windows && !darwin && !linux
+
+/*
+ * Copyright (c) 2026 The XGo Authors (xgo.dev). All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package projectdriver
+
+import (
+	"context"
+	"os/exec"
+)
+
+func runDriverProcess(ctx context.Context, cmd *exec.Cmd) (ProcessStatus, error) {
+	if err := ctx.Err(); err != nil {
+		return ProcessStatus{}, err
+	}
+	if err := cmd.Start(); err != nil {
+		return ProcessStatus{}, err
+	}
+	wait := make(chan error, 1)
+	go func() { wait <- cmd.Wait() }()
+	select {
+	case err := <-wait:
+		return driverExitStatus(ctx, err)
+	case <-ctx.Done():
+		_ = cmd.Process.Kill()
+		<-wait
+		return ProcessStatus{}, context.Cause(ctx)
+	}
+}

--- a/cmd/internal/projectdriver/process_terminal_darwin.go
+++ b/cmd/internal/projectdriver/process_terminal_darwin.go
@@ -1,0 +1,96 @@
+//go:build darwin
+
+/*
+ * Copyright (c) 2026 The XGo Authors (xgo.dev). All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package projectdriver
+
+import (
+	"errors"
+	"runtime"
+	"syscall"
+	"unsafe"
+
+	"golang.org/x/sys/unix"
+)
+
+const (
+	darwinSIGBlock     = 1
+	darwinSIGSetMask   = 3
+	darwinPID          = 1   // P_PID
+	darwinSiginfoBytes = 104 // sizeof(siginfo_t)
+)
+
+type darwinWaitidSiginfo struct {
+	Signo  int32
+	Errno  int32
+	Code   int32
+	PID    int32
+	UID    uint32
+	Status int32
+	_      [darwinSiginfoBytes - 24]byte
+}
+
+func isDriverTerminal(fd int) (bool, error) {
+	_, err := unix.IoctlGetTermios(fd, unix.TIOCGETA)
+	if errors.Is(err, syscall.ENOTTY) || errors.Is(err, syscall.ENODEV) {
+		return false, nil
+	}
+	return err == nil, err
+}
+
+func setTerminalForegroundProcessGroup(fd, pgid int) error {
+	runtime.LockOSThread()
+	defer runtime.UnlockOSThread()
+	blocked := uint32(1 << (uint(syscall.SIGTTOU) - 1))
+	var old uint32
+	if err := darwinPthreadSigmask(darwinSIGBlock, &blocked, &old); err != nil {
+		return err
+	}
+	setErr := unix.IoctlSetPointerInt(fd, unix.TIOCSPGRP, pgid)
+	restoreErr := darwinPthreadSigmask(darwinSIGSetMask, &old, nil)
+	return errors.Join(setErr, restoreErr)
+}
+
+func darwinPthreadSigmask(how int, set, old *uint32) error {
+	_, _, errno := syscall.RawSyscall(
+		syscall.SYS___PTHREAD_SIGMASK,
+		uintptr(how),
+		uintptr(unsafe.Pointer(set)),
+		uintptr(unsafe.Pointer(old)),
+	)
+	if errno != 0 {
+		return errno
+	}
+	return nil
+}
+
+func waitidStopped(pid int) (syscall.Signal, bool, error) {
+	var info darwinWaitidSiginfo
+	_, _, errno := syscall.RawSyscall6(
+		syscall.SYS_WAITID,
+		darwinPID,
+		uintptr(pid),
+		uintptr(unsafe.Pointer(&info)),
+		unix.WSTOPPED|unix.WNOHANG,
+		0,
+		0,
+	)
+	if errno != 0 {
+		return 0, false, errno
+	}
+	return syscall.Signal(info.Status), info.Signo != 0 && info.Code == childStoppedCode, nil
+}

--- a/cmd/internal/projectdriver/process_terminal_linux.go
+++ b/cmd/internal/projectdriver/process_terminal_linux.go
@@ -1,0 +1,63 @@
+//go:build linux
+
+/*
+ * Copyright (c) 2026 The XGo Authors (xgo.dev). All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package projectdriver
+
+import (
+	"errors"
+	"runtime"
+	"syscall"
+	"unsafe"
+
+	"golang.org/x/sys/unix"
+)
+
+func isDriverTerminal(fd int) (bool, error) {
+	_, err := unix.IoctlGetTermios(fd, unix.TCGETS)
+	if errors.Is(err, syscall.ENOTTY) || errors.Is(err, syscall.ENODEV) {
+		return false, nil
+	}
+	return err == nil, err
+}
+
+func setTerminalForegroundProcessGroup(fd, pgid int) error {
+	// Block SIGTTOU on this thread while changing the foreground group.
+	runtime.LockOSThread()
+	defer runtime.UnlockOSThread()
+	var blocked, old unix.Sigset_t
+	blocked.Val[0] = 1 << (uint(syscall.SIGTTOU) - 1)
+	if err := unix.PthreadSigmask(unix.SIG_BLOCK, &blocked, &old); err != nil {
+		return err
+	}
+	setErr := unix.IoctlSetPointerInt(fd, unix.TIOCSPGRP, pgid)
+	restoreErr := unix.PthreadSigmask(unix.SIG_SETMASK, &old, nil)
+	return errors.Join(setErr, restoreErr)
+}
+
+func waitidStopped(pid int) (syscall.Signal, bool, error) {
+	var info unix.Siginfo
+	err := unix.Waitid(unix.P_PID, pid, &info, unix.WSTOPPED|unix.WNOHANG, nil)
+	// The SIGCHLD union follows three ints and is pointer-aligned; si_status
+	// follows its pid and uid fields.
+	offset := uintptr(12)
+	if unsafe.Sizeof(uintptr(0)) == 8 {
+		offset = 16
+	}
+	status := *(*int32)(unsafe.Add(unsafe.Pointer(&info), offset+8))
+	return syscall.Signal(status), info.Signo != 0 && info.Code == childStoppedCode, err
+}

--- a/cmd/internal/projectdriver/process_terminal_unix.go
+++ b/cmd/internal/projectdriver/process_terminal_unix.go
@@ -1,0 +1,192 @@
+//go:build darwin || linux
+
+/*
+ * Copyright (c) 2026 The XGo Authors (xgo.dev). All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package projectdriver
+
+import (
+	"context"
+	"errors"
+	"os"
+	"syscall"
+
+	"golang.org/x/sys/unix"
+)
+
+// Serialize terminal handoffs without blocking context cancellation.
+var driverTerminalLease = func() chan struct{} {
+	lease := make(chan struct{}, 1)
+	lease <- struct{}{}
+	return lease
+}()
+
+type unixDriverTerminal struct {
+	fd                      int
+	parentPgrp              int
+	initialParentForeground bool
+	driverOwnsForeground    bool
+}
+
+const childStoppedCode = 5 // CLD_STOPPED
+
+// Observe stops without competing with cmd.Wait for exit status.
+func driverStoppedSignal(pid int) (syscall.Signal, bool, error) {
+	for {
+		stop, ok, err := waitidStopped(pid)
+		if errors.Is(err, syscall.EINTR) {
+			continue
+		}
+		if errors.Is(err, syscall.ECHILD) || errors.Is(err, syscall.ESRCH) {
+			return 0, false, nil
+		}
+		if err != nil {
+			return 0, false, err
+		}
+		return stop, ok, nil
+	}
+}
+
+func acquireDriverTerminal(ctx context.Context, stdin any) (driverTerminal, error) {
+	file, ok := stdin.(*os.File)
+	if !ok {
+		return nil, nil
+	}
+	fd, err := duplicateDriverTerminalFD(file)
+	if err != nil {
+		return nil, err
+	}
+
+	_, terminal, err := terminalForegroundProcessGroup(fd)
+	if err != nil {
+		_ = unix.Close(fd)
+		return nil, err
+	}
+	if !terminal {
+		_ = unix.Close(fd)
+		return nil, nil
+	}
+
+	if err := acquireDriverTerminalLease(ctx); err != nil {
+		_ = unix.Close(fd)
+		return nil, err
+	}
+	foreground, terminal, err := terminalForegroundProcessGroup(fd)
+	if err != nil || !terminal {
+		releaseDriverTerminalLease()
+		_ = unix.Close(fd)
+		return nil, err
+	}
+	parentPgrp := syscall.Getpgrp()
+	return &unixDriverTerminal{
+		fd: fd, parentPgrp: parentPgrp, initialParentForeground: foreground == parentPgrp,
+	}, nil
+}
+
+func duplicateDriverTerminalFD(file *os.File) (int, error) {
+	raw, err := file.SyscallConn()
+	if err != nil {
+		return -1, err
+	}
+	fd := -1
+	var duplicateErr error
+	if err := raw.Control(func(source uintptr) {
+		fd, duplicateErr = unix.FcntlInt(source, unix.F_DUPFD_CLOEXEC, 0)
+	}); err != nil {
+		return -1, err
+	}
+	return fd, duplicateErr
+}
+
+func acquireDriverTerminalLease(ctx context.Context) error {
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-driverTerminalLease:
+		// Both select cases may become ready together.
+		if err := ctx.Err(); err != nil {
+			releaseDriverTerminalLease()
+			return err
+		}
+		return nil
+	}
+}
+
+func releaseDriverTerminalLease() {
+	driverTerminalLease <- struct{}{}
+}
+
+func terminalForegroundProcessGroup(fd int) (pgid int, terminal bool, err error) {
+	terminal, err = isDriverTerminal(fd)
+	if err != nil || !terminal {
+		return 0, terminal, err
+	}
+	pgid, err = unix.IoctlGetInt(fd, unix.TIOCGPGRP)
+	if errors.Is(err, syscall.ENOTTY) || errors.Is(err, syscall.ENODEV) {
+		return 0, false, nil
+	}
+	return pgid, err == nil, err
+}
+
+func (t *unixDriverTerminal) configure(attr *syscall.SysProcAttr) {
+	if !t.initialParentForeground {
+		// A background invocation must not steal the terminal.
+		return
+	}
+	// Foreground makes setpgid and TIOCSPGRP atomic with child startup.
+	attr.Foreground = true
+	attr.Ctty = t.fd
+	t.driverOwnsForeground = true
+}
+
+func (t *unixDriverTerminal) restore() error {
+	if !t.driverOwnsForeground {
+		return nil
+	}
+	if err := setTerminalForegroundProcessGroup(t.fd, t.parentPgrp); err != nil {
+		return err
+	}
+	t.driverOwnsForeground = false
+	return nil
+}
+
+func (t *unixDriverTerminal) handoffIfParentForeground(pgid int) (bool, error) {
+	if t.driverOwnsForeground {
+		return false, nil
+	}
+	foreground, terminal, err := terminalForegroundProcessGroup(t.fd)
+	if err != nil {
+		return false, err
+	}
+	if !terminal || foreground != t.parentPgrp {
+		// The shell kept this job in the background.
+		return false, nil
+	}
+	if err := setTerminalForegroundProcessGroup(t.fd, pgid); err != nil {
+		return false, err
+	}
+	t.driverOwnsForeground = true
+	return true, nil
+}
+
+func (t *unixDriverTerminal) suspendParent(stop syscall.Signal) error {
+	return syscall.Kill(-t.parentPgrp, stop)
+}
+
+func (t *unixDriverTerminal) release() {
+	_ = unix.Close(t.fd)
+	releaseDriverTerminalLease()
+}

--- a/cmd/internal/projectdriver/process_tty_test.go
+++ b/cmd/internal/projectdriver/process_tty_test.go
@@ -1,0 +1,632 @@
+//go:build darwin || linux
+
+/*
+ * Copyright (c) 2026 The XGo Authors (xgo.dev). All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package projectdriver
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"os/signal"
+	"path/filepath"
+	"runtime"
+	"strconv"
+	"strings"
+	"syscall"
+	"testing"
+	"time"
+
+	"golang.org/x/sys/unix"
+)
+
+const driverTTYHelperEnv = "XGO_DRIVER_TTY_HELPER"
+
+type ttyScenario struct {
+	t           *testing.T
+	cancel      context.CancelFunc
+	input       *os.File
+	wait        chan error
+	output      bytes.Buffer
+	cleanupPIDs []string
+	done        bool
+}
+
+func startTTYScenario(t *testing.T, timeout time.Duration, mode string, cleanupPIDs []string, paths ...string) *ttyScenario {
+	t.Helper()
+	script, err := exec.LookPath("script")
+	if err != nil {
+		t.Skip("script(1) is required for PTY job-control coverage")
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	cmd := driverTTYScriptCommand(ctx, script, mode, paths...)
+	cmd.Env = append(os.Environ(), driverTTYHelperEnv+"=1")
+	input, writer, err := os.Pipe()
+	if err != nil {
+		cancel()
+		t.Fatal(err)
+	}
+	s := &ttyScenario{t: t, cancel: cancel, input: writer, wait: make(chan error, 1), cleanupPIDs: cleanupPIDs}
+	cmd.Stdin, cmd.Stdout, cmd.Stderr = input, &s.output, &s.output
+	if err := cmd.Start(); err != nil {
+		input.Close()
+		writer.Close()
+		cancel()
+		t.Fatal(err)
+	}
+	input.Close()
+	go func() { s.wait <- cmd.Wait() }()
+	t.Cleanup(func() {
+		if s.done {
+			return
+		}
+		s.cancel()
+		_ = s.input.Close()
+		for _, path := range s.cleanupPIDs {
+			killRecordedTTYHelper(path)
+		}
+		select {
+		case <-s.wait:
+		case <-time.After(5 * time.Second):
+		}
+	})
+	return s
+}
+
+func (s *ttyScenario) waitFile(path, description string) []byte {
+	s.t.Helper()
+	data, err := waitForHelperFile(path, 5*time.Second)
+	if err != nil {
+		s.t.Fatalf("%s: %v\n%s", description, err, s.output.String())
+	}
+	return data
+}
+
+func (s *ttyScenario) write(data []byte, description string) {
+	s.t.Helper()
+	if _, err := s.input.Write(data); err != nil {
+		s.t.Fatalf("%s: %v\n%s", description, err, s.output.String())
+	}
+}
+
+func (s *ttyScenario) finish(description string) {
+	s.t.Helper()
+	_ = s.input.Close()
+	select {
+	case err := <-s.wait:
+		if err != nil {
+			s.t.Fatalf("%s: %v\n%s", description, err, s.output.String())
+		}
+		s.done = true
+		s.cancel()
+	case <-time.After(5 * time.Second):
+		s.t.Fatalf("%s did not exit\n%s", description, s.output.String())
+	}
+}
+
+// A real PTY catches regressions where SIGTTIN stops the driver.
+func TestRunDriverProcessInteractiveTTY(t *testing.T) {
+	dir := t.TempDir()
+	parentPID := filepath.Join(dir, "parent-pid")
+	childPID := filepath.Join(dir, "child-pid")
+	ready := filepath.Join(dir, "ready")
+	received := filepath.Join(dir, "received")
+	s := startTTYScenario(t, 15*time.Second, "parent", []string{parentPID, childPID}, parentPID, childPID, ready, received)
+	s.waitFile(ready, "driver did not become foreground-ready")
+	const want = "interactive driver input\n"
+	s.write([]byte(want), "write PTY input")
+	data := s.waitFile(received, "driver did not read PTY input")
+	s.finish("PTY helper")
+	if string(data) != want {
+		t.Fatalf("driver read %q, want %q", data, want)
+	}
+}
+
+func TestRunDriverProcessSuspendResumeTTY(t *testing.T) {
+	dir := t.TempDir()
+	shellPID := filepath.Join(dir, "shell-pid")
+	parentPID := filepath.Join(dir, "parent-pid")
+	childPID := filepath.Join(dir, "child-pid")
+	ready := filepath.Join(dir, "ready")
+	parentStopped := filepath.Join(dir, "parent-stopped")
+	resume := filepath.Join(dir, "resume")
+	continued := filepath.Join(dir, "continued")
+	received := filepath.Join(dir, "received")
+	s := startTTYScenario(t, 20*time.Second, "shell", []string{shellPID, parentPID, childPID},
+		shellPID, parentStopped, resume, parentPID, childPID, ready, continued, received)
+	s.waitFile(ready, "driver did not become foreground-ready")
+	s.write([]byte{0x1a}, "write Ctrl-Z to PTY")
+	s.waitFile(parentStopped, "parent job did not stop")
+	writeTTYHelperFile(t, resume, "fg")
+	s.waitFile(continued, "driver did not receive SIGCONT")
+	const want = "input after fg\n"
+	s.write([]byte(want), "write resumed PTY input")
+	data := s.waitFile(received, "resumed driver did not read PTY input")
+	s.finish("suspend/resume PTY helper")
+	if string(data) != want {
+		t.Fatalf("resumed driver read %q, want %q", data, want)
+	}
+}
+
+func TestRunDriverProcessInitialBackgroundThenForegroundTTY(t *testing.T) {
+	dir := t.TempDir()
+	shellPID := filepath.Join(dir, "shell-pid")
+	parentPID := filepath.Join(dir, "parent-pid")
+	childPID := filepath.Join(dir, "child-pid")
+	ready := filepath.Join(dir, "ready")
+	parentStopped := filepath.Join(dir, "parent-stopped")
+	foreground := filepath.Join(dir, "foreground")
+	continued := filepath.Join(dir, "continued")
+	received := filepath.Join(dir, "received")
+	s := startTTYScenario(t, 20*time.Second, "initial-background-shell", []string{shellPID, parentPID, childPID},
+		shellPID, parentStopped, foreground, parentPID, childPID, ready, continued, received)
+	s.waitFile(ready, "background driver did not start")
+	s.waitFile(parentStopped, "background parent did not propagate SIGTTIN stop")
+	writeTTYHelperFile(t, foreground, "fg")
+	s.waitFile(continued, "foregrounded background driver did not continue")
+	const want = "one fg is enough\n"
+	s.write([]byte(want), "write foregrounded driver input")
+	data := s.waitFile(received, "foregrounded driver did not read")
+	s.finish("initial-background PTY helper")
+	if string(data) != want {
+		t.Fatalf("foregrounded driver read %q, want %q", data, want)
+	}
+}
+
+func TestRunDriverProcessBackgroundThenLaterForegroundTTY(t *testing.T) {
+	dir := t.TempDir()
+	shellPID := filepath.Join(dir, "shell-pid")
+	parentPID := filepath.Join(dir, "parent-pid")
+	childPID := filepath.Join(dir, "child-pid")
+	ready := filepath.Join(dir, "ready")
+	parentStopped := filepath.Join(dir, "parent-stopped")
+	background := filepath.Join(dir, "background")
+	continued := filepath.Join(dir, "continued")
+	foreground := filepath.Join(dir, "foreground")
+	allowRead := filepath.Join(dir, "allow-read")
+	driverForeground := filepath.Join(dir, "driver-foreground")
+	received := filepath.Join(dir, "received")
+	s := startTTYScenario(t, 20*time.Second, "background-foreground-shell", []string{shellPID, parentPID, childPID},
+		shellPID, parentStopped, background, foreground, parentPID, childPID, ready, continued, allowRead, driverForeground, received)
+	s.waitFile(ready, "driver did not become foreground-ready")
+	s.write([]byte{0x1a}, "write Ctrl-Z to PTY")
+	s.waitFile(parentStopped, "parent job did not stop")
+	writeTTYHelperFile(t, background, "bg")
+	s.waitFile(continued, "backgrounded driver did not continue")
+	// A running job can be foregrounded by changing TPGID alone.
+	writeTTYHelperFile(t, foreground, "fg")
+	writeTTYHelperFile(t, allowRead, "read")
+	s.waitFile(driverForeground, "running background driver did not receive TTY handoff")
+	const want = "input after later fg\n"
+	s.write([]byte(want), "write later-foreground input")
+	data := s.waitFile(received, "later-foreground driver did not read")
+	s.finish("background/foreground PTY helper")
+	if string(data) != want {
+		t.Fatalf("later-foreground driver read %q, want %q", data, want)
+	}
+}
+
+func TestDriverTerminalLeaseCancellation(t *testing.T) {
+	if err := acquireDriverTerminalLease(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	held := true
+	defer func() {
+		if held {
+			releaseDriverTerminalLease()
+		}
+	}()
+	ctx, cancel := context.WithCancel(context.Background())
+	result := make(chan error, 1)
+	go func() { result <- acquireDriverTerminalLease(ctx) }()
+	cancel()
+	select {
+	case err := <-result:
+		if !errors.Is(err, context.Canceled) {
+			t.Fatalf("lease wait = %v, want context cancellation", err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("canceled terminal lease wait did not return")
+	}
+	releaseDriverTerminalLease()
+	held = false
+	ctx, cancel = context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	if err := acquireDriverTerminalLease(ctx); err != nil {
+		t.Fatalf("reacquire terminal lease after cancellation: %v", err)
+	}
+	releaseDriverTerminalLease()
+}
+
+func TestAcquireDriverTerminalPreservesFilePoller(t *testing.T) {
+	reader, writer, err := os.Pipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer reader.Close()
+	defer writer.Close()
+
+	terminal, err := acquireDriverTerminal(context.Background(), reader)
+	if err != nil || terminal != nil {
+		t.Fatalf("acquireDriverTerminal(pipe) = (%v, %v)", terminal, err)
+	}
+	if err := reader.SetReadDeadline(time.Now().Add(time.Second)); err != nil {
+		t.Fatalf("stdin deadline stopped working: %v", err)
+	}
+}
+
+type cancelingTerminal struct {
+	cancel          context.CancelFunc
+	cancelOnRestore bool
+	restores        int
+	suspends        int
+}
+
+func (*cancelingTerminal) configure(*syscall.SysProcAttr) {}
+func (*cancelingTerminal) release()                       {}
+func (*cancelingTerminal) handoffIfParentForeground(int) (bool, error) {
+	return false, nil
+}
+func (t *cancelingTerminal) restore() error {
+	t.restores++
+	if t.cancelOnRestore {
+		t.cancel()
+	}
+	return nil
+}
+func (t *cancelingTerminal) suspendParent(syscall.Signal) error {
+	t.suspends++
+	return nil
+}
+
+func TestSuspendDriverJobHonorsCancellation(t *testing.T) {
+	for _, test := range []struct {
+		name            string
+		cancelBefore    bool
+		cancelOnRestore bool
+		wantRestores    int
+	}{
+		{name: "before restore", cancelBefore: true},
+		{name: "after restore", cancelOnRestore: true, wantRestores: 1},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			ctx, cancel := context.WithCancel(context.Background())
+			terminal := &cancelingTerminal{cancel: cancel, cancelOnRestore: test.cancelOnRestore}
+			if test.cancelBefore {
+				cancel()
+			}
+			err := suspendDriverJob(ctx, terminal, 12345, syscall.SIGTSTP)
+			if !errors.Is(err, context.Canceled) || terminal.restores != test.wantRestores || terminal.suspends != 0 {
+				t.Fatalf("suspend = %v, restores = %d, suspends = %d", err, terminal.restores, terminal.suspends)
+			}
+		})
+	}
+}
+
+func TestDriverTTYHelper(t *testing.T) {
+	if os.Getenv(driverTTYHelperEnv) != "1" {
+		return
+	}
+	args := driverTTYHelperArgs()
+	if len(args) == 0 {
+		t.Fatal("missing TTY helper mode")
+	}
+	switch args[0] {
+	case "initial-background-shell":
+		if len(args) != 9 {
+			t.Fatalf("initial-background-shell args = %q", args)
+		}
+		writeTTYHelperPID(t, args[1])
+		process := startTTYHelper(t, false, "background-parent", args[4], args[5], args[6], args[7], args[8])
+		defer process.Release()
+		status := waitTTYHelper(t, process.Pid, syscall.WUNTRACED)
+		if !status.Stopped() || status.StopSignal() != syscall.SIGTTIN {
+			t.Fatalf("background parent wait status = %#x, want SIGTTIN stop", int(status))
+		}
+		assertTTYHelperForeground(t, "background test shell")
+		writeTTYHelperFile(t, args[2], "stopped")
+		waitTTYHelperFile(t, args[3])
+		if err := setTerminalForegroundProcessGroup(int(os.Stdin.Fd()), process.Pid); err != nil {
+			t.Fatalf("foreground background parent: %v", err)
+		}
+		if err := syscall.Kill(-process.Pid, syscall.SIGCONT); err != nil {
+			t.Fatalf("continue background parent: %v", err)
+		}
+		waitTTYHelperExit(t, process, "background parent")
+	case "background-foreground-shell":
+		if len(args) != 12 {
+			t.Fatalf("background-foreground-shell args = %q", args)
+		}
+		writeTTYHelperPID(t, args[1])
+		process := startTTYHelper(t, true, "delayed-parent", args[5], args[6], args[7], args[8], args[9], args[10], args[11])
+		defer process.Release()
+		status := waitTTYHelper(t, process.Pid, syscall.WUNTRACED)
+		if !status.Stopped() || status.StopSignal() != syscall.SIGTSTP {
+			t.Fatalf("foreground parent wait status = %#x, want SIGTSTP stop", int(status))
+		}
+		if err := setTerminalForegroundProcessGroup(int(os.Stdin.Fd()), syscall.Getpgrp()); err != nil {
+			t.Fatalf("restore shell before bg: %v", err)
+		}
+		writeTTYHelperFile(t, args[2], "stopped")
+		waitTTYHelperFile(t, args[3])
+		if err := syscall.Kill(-process.Pid, syscall.SIGCONT); err != nil {
+			t.Fatalf("background parent: %v", err)
+		}
+		waitTTYHelperFile(t, args[4])
+		// A running job may be foregrounded without SIGCONT.
+		if err := setTerminalForegroundProcessGroup(int(os.Stdin.Fd()), process.Pid); err != nil {
+			t.Fatalf("foreground running parent: %v", err)
+		}
+		waitTTYHelperExit(t, process, "later-foreground parent")
+	case "shell":
+		if len(args) != 9 {
+			t.Fatalf("shell args = %q", args)
+		}
+		writeTTYHelperPID(t, args[1])
+		process := startTTYHelper(t, true, "suspend-parent", args[4], args[5], args[6], args[7], args[8])
+		defer process.Release()
+		status := waitTTYHelper(t, process.Pid, syscall.WUNTRACED)
+		if !status.Stopped() || status.StopSignal() != syscall.SIGTSTP {
+			t.Fatalf("parent wait status = %#x, want SIGTSTP stop", int(status))
+		}
+		foreground, err := unix.IoctlGetInt(int(os.Stdin.Fd()), unix.TIOCGPGRP)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if foreground != process.Pid {
+			t.Fatalf("terminal foreground = %d, want stopped parent %d", foreground, process.Pid)
+		}
+		if err := setTerminalForegroundProcessGroup(int(os.Stdin.Fd()), syscall.Getpgrp()); err != nil {
+			t.Fatalf("restore test shell foreground: %v", err)
+		}
+		writeTTYHelperFile(t, args[2], "stopped")
+		waitTTYHelperFile(t, args[3])
+		if err := setTerminalForegroundProcessGroup(int(os.Stdin.Fd()), process.Pid); err != nil {
+			t.Fatalf("foreground stopped parent: %v", err)
+		}
+		if err := syscall.Kill(-process.Pid, syscall.SIGCONT); err != nil {
+			t.Fatalf("continue parent: %v", err)
+		}
+		waitTTYHelperExit(t, process, "parent")
+	case "parent":
+		runTTYParent(t, args, 5, "reader", "parent")
+	case "suspend-parent":
+		runTTYParent(t, args, 6, "suspend-reader", "resumed parent")
+	case "background-parent":
+		runTTYParent(t, args, 6, "background-reader", "foregrounded background parent")
+	case "delayed-parent":
+		runTTYParent(t, args, 8, "delayed-reader", "later-foreground parent")
+	case "reader":
+		if len(args) != 4 {
+			t.Fatalf("reader args = %q", args)
+		}
+		writeTTYHelperPID(t, args[1])
+		assertTTYHelperForeground(t, "driver")
+		writeTTYHelperFile(t, args[2], "ready")
+		line := readTTYInput(t)
+		writeTTYHelperFile(t, args[3], line)
+	case "suspend-reader", "background-reader":
+		if len(args) != 5 {
+			t.Fatalf("%s args = %q", args[0], args)
+		}
+		writeTTYHelperPID(t, args[1])
+		if args[0] == "suspend-reader" {
+			assertTTYHelperForeground(t, args[0])
+		}
+		continued := make(chan os.Signal, 1)
+		signal.Notify(continued, syscall.SIGCONT)
+		defer signal.Stop(continued)
+		go func() {
+			<-continued
+			_ = os.WriteFile(args[3], []byte("continued"), 0o600)
+		}()
+		writeTTYHelperFile(t, args[2], "ready")
+		line := readTTYInput(t)
+		assertTTYHelperForeground(t, args[0])
+		writeTTYHelperFile(t, args[4], line)
+	case "delayed-reader":
+		if len(args) != 7 {
+			t.Fatalf("delayed-reader args = %q", args)
+		}
+		writeTTYHelperPID(t, args[1])
+		assertTTYHelperForeground(t, "delayed driver")
+		continued := make(chan os.Signal, 1)
+		signal.Notify(continued, syscall.SIGCONT)
+		defer signal.Stop(continued)
+		go func() {
+			<-continued
+			_ = os.WriteFile(args[3], []byte("continued"), 0o600)
+		}()
+		writeTTYHelperFile(t, args[2], "ready")
+		waitTTYHelperFile(t, args[4])
+		if err := waitForTTYForeground(syscall.Getpgrp(), 5*time.Second); err != nil {
+			t.Fatal(err)
+		}
+		writeTTYHelperFile(t, args[5], "foreground")
+		line := readTTYInput(t)
+		writeTTYHelperFile(t, args[6], line)
+	default:
+		t.Fatalf("unknown TTY helper mode %q", args[0])
+	}
+}
+
+func runTTYParent(t *testing.T, args []string, wantArgs int, childMode, label string) {
+	t.Helper()
+	if len(args) != wantArgs {
+		t.Fatalf("%s args = %q", args[0], args)
+	}
+	writeTTYHelperPID(t, args[1])
+	cmd := driverTTYHelperCommand(append([]string{childMode}, args[2:]...)...)
+	cmd.Stdin, cmd.Stdout, cmd.Stderr = os.Stdin, os.Stdout, os.Stderr
+	status, err := runDriverProcess(context.Background(), cmd)
+	if err != nil || !status.Success() {
+		t.Fatalf("runDriverProcess() = (%+v, %v)", status, err)
+	}
+	assertTTYHelperForeground(t, label)
+}
+
+func readTTYInput(t *testing.T) string {
+	t.Helper()
+	line, err := bufio.NewReader(os.Stdin).ReadString('\n')
+	if err != nil {
+		t.Fatal(err)
+	}
+	return line
+}
+
+func assertTTYHelperForeground(t *testing.T, name string) {
+	t.Helper()
+	foreground, err := unix.IoctlGetInt(int(os.Stdin.Fd()), unix.TIOCGPGRP)
+	if err != nil {
+		t.Fatalf("read terminal foreground process group: %v", err)
+	}
+	if foreground != syscall.Getpgrp() {
+		t.Fatalf("%s process group = %d, terminal foreground = %d", name, syscall.Getpgrp(), foreground)
+	}
+}
+
+func driverTTYScriptCommand(ctx context.Context, script, mode string, paths ...string) *exec.Cmd {
+	args := []string{os.Args[0], "-test.run=^TestDriverTTYHelper$", "--", mode}
+	args = append(args, paths...)
+	if runtime.GOOS == "darwin" {
+		return exec.CommandContext(ctx, script, append([]string{"-q", "/dev/null"}, args...)...)
+	}
+	quoted := make([]string, len(args))
+	for i, arg := range args {
+		quoted[i] = "'" + strings.ReplaceAll(arg, "'", `'"'"'`) + "'"
+	}
+	return exec.CommandContext(ctx, script, "-q", "-e", "-c", strings.Join(quoted, " "), "/dev/null")
+}
+
+func startTTYHelper(t *testing.T, foreground bool, args ...string) *os.Process {
+	t.Helper()
+	commandArgs := []string{os.Args[0], "-test.run=^TestDriverTTYHelper$", "--"}
+	commandArgs = append(commandArgs, args...)
+	attr := &syscall.SysProcAttr{Setpgid: true, Pgid: 0}
+	if foreground {
+		attr.Foreground = true
+		attr.Ctty = int(os.Stdin.Fd())
+	}
+	process, err := os.StartProcess(os.Args[0], commandArgs, &os.ProcAttr{
+		Env:   append(os.Environ(), driverTTYHelperEnv+"=1"),
+		Files: []*os.File{os.Stdin, os.Stdout, os.Stderr},
+		Sys:   attr,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	return process
+}
+
+func waitTTYHelper(t *testing.T, pid, options int) syscall.WaitStatus {
+	t.Helper()
+	for {
+		var status syscall.WaitStatus
+		got, err := syscall.Wait4(pid, &status, options, nil)
+		if errors.Is(err, syscall.EINTR) {
+			continue
+		}
+		if err != nil {
+			t.Fatal(err)
+		}
+		if got != pid {
+			t.Fatalf("wait4() = %d, want %d", got, pid)
+		}
+		return status
+	}
+}
+
+func waitTTYHelperExit(t *testing.T, process *os.Process, label string) {
+	t.Helper()
+	status := waitTTYHelper(t, process.Pid, 0)
+	if err := setTerminalForegroundProcessGroup(int(os.Stdin.Fd()), syscall.Getpgrp()); err != nil {
+		t.Fatalf("restore test shell: %v", err)
+	}
+	if !status.Exited() || status.ExitStatus() != 0 {
+		t.Fatalf("%s wait status = %#x", label, int(status))
+	}
+}
+
+func waitForTTYForeground(pgid int, timeout time.Duration) error {
+	deadline := time.Now().Add(timeout)
+	for {
+		foreground, err := unix.IoctlGetInt(int(os.Stdin.Fd()), unix.TIOCGPGRP)
+		if err != nil {
+			return err
+		}
+		if foreground == pgid {
+			return nil
+		}
+		if time.Now().After(deadline) {
+			return fmt.Errorf("terminal foreground = %d, want %d", foreground, pgid)
+		}
+		time.Sleep(driverProcessPollInterval)
+	}
+}
+
+func driverTTYHelperCommand(args ...string) *exec.Cmd {
+	commandArgs := []string{"-test.run=^TestDriverTTYHelper$", "--"}
+	commandArgs = append(commandArgs, args...)
+	cmd := exec.Command(os.Args[0], commandArgs...)
+	cmd.Env = append(os.Environ(), driverTTYHelperEnv+"=1")
+	return cmd
+}
+
+func driverTTYHelperArgs() []string {
+	for i, arg := range os.Args {
+		if arg == "--" {
+			return os.Args[i+1:]
+		}
+	}
+	return nil
+}
+
+func writeTTYHelperPID(t *testing.T, path string) {
+	t.Helper()
+	writeTTYHelperFile(t, path, strconv.Itoa(os.Getpid()))
+}
+
+func writeTTYHelperFile(t *testing.T, path, value string) {
+	t.Helper()
+	if err := os.WriteFile(path, []byte(value), 0o600); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func waitTTYHelperFile(t *testing.T, path string) {
+	t.Helper()
+	if _, err := waitForHelperFile(path, 5*time.Second); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func killRecordedTTYHelper(path string) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return
+	}
+	pid, err := strconv.Atoi(string(data))
+	if err != nil || pid <= 0 {
+		return
+	}
+	_ = syscall.Kill(-pid, syscall.SIGKILL)
+	_ = syscall.Kill(pid, syscall.SIGKILL)
+}

--- a/cmd/internal/projectdriver/process_unix.go
+++ b/cmd/internal/projectdriver/process_unix.go
@@ -1,0 +1,284 @@
+//go:build darwin || linux
+
+/*
+ * Copyright (c) 2026 The XGo Authors (xgo.dev). All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package projectdriver
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"syscall"
+	"time"
+)
+
+const (
+	driverProcessGracePeriod  = 2 * time.Second
+	driverProcessKillWait     = 2 * time.Second
+	driverProcessPollInterval = 10 * time.Millisecond
+)
+
+func runDriverProcess(ctx context.Context, cmd *exec.Cmd) (status ProcessStatus, retErr error) {
+	if err := ctx.Err(); err != nil {
+		return ProcessStatus{}, err
+	}
+	terminal, err := acquireDriverTerminal(ctx, cmd.Stdin)
+	if err != nil {
+		return ProcessStatus{}, fmt.Errorf("inspect driver terminal: %w", err)
+	}
+	if terminal != nil {
+		defer terminal.release()
+		defer func() {
+			if err := terminal.restore(); err != nil {
+				status = ProcessStatus{}
+				retErr = errors.Join(retErr, fmt.Errorf("restore driver terminal foreground process group: %w", err))
+			}
+		}()
+	}
+	// Recheck after waiting for the terminal lease.
+	if err := ctx.Err(); err != nil {
+		return ProcessStatus{}, err
+	}
+	configureDriverProcessGroup(cmd, terminal)
+	if err := cmd.Start(); err != nil {
+		return ProcessStatus{}, err
+	}
+	pgid := cmd.Process.Pid
+	wait := make(chan error, 1)
+	go func() {
+		wait <- cmd.Wait()
+	}()
+	return waitDriverProcess(ctx, pgid, terminal, wait)
+}
+
+func waitDriverProcess(ctx context.Context, pgid int, terminal driverTerminal, wait <-chan error) (ProcessStatus, error) {
+	var stopTicks <-chan time.Time
+	if terminal != nil {
+		stopPoll := time.NewTicker(driverProcessPollInterval)
+		defer stopPoll.Stop()
+		stopTicks = stopPoll.C
+	}
+	for {
+		select {
+		case err := <-wait:
+			return finishDriverProcess(ctx, pgid, err)
+		case <-ctx.Done():
+			return cancelDriverProcess(ctx, pgid, wait)
+		case <-stopTicks:
+			if ctx.Err() != nil {
+				return cancelDriverProcess(ctx, pgid, wait)
+			}
+			select {
+			case err := <-wait:
+				return finishDriverProcess(ctx, pgid, err)
+			default:
+			}
+			if err := pollDriverJobControl(ctx, terminal, pgid); err != nil {
+				if ctx.Err() != nil {
+					return cancelDriverProcess(ctx, pgid, wait)
+				}
+				return abortDriverProcess(pgid, wait, err)
+			}
+		}
+	}
+}
+
+func pollDriverJobControl(ctx context.Context, terminal driverTerminal, pgid int) error {
+	handedOff, err := tryForegroundDriver(terminal, pgid)
+	if err != nil || handedOff {
+		return err
+	}
+	stop, ok, err := driverStoppedSignal(pgid)
+	if err != nil {
+		return fmt.Errorf("observe stopped driver: %w", err)
+	}
+	if !ok {
+		return nil
+	}
+	return suspendDriverJob(ctx, terminal, pgid, stop)
+}
+
+type driverTerminal interface {
+	configure(*syscall.SysProcAttr)
+	restore() error
+	handoffIfParentForeground(int) (bool, error)
+	suspendParent(syscall.Signal) error
+	release()
+}
+
+func finishDriverProcess(ctx context.Context, pgid int, waitErr error) (ProcessStatus, error) {
+	if _, cleanupErr := stopDriverProcessGroup(pgid, syscall.SIGTERM, nil); cleanupErr != nil {
+		return ProcessStatus{}, cleanupErr
+	}
+	return driverExitStatus(ctx, waitErr)
+}
+
+func cancelDriverProcess(ctx context.Context, pgid int, wait <-chan error) (ProcessStatus, error) {
+	waitErr, cleanupErr := stopDriverProcessGroup(pgid, driverCancellationSignal(ctx), wait)
+	if cleanupErr != nil {
+		return ProcessStatus{}, cleanupErr
+	}
+	return driverExitStatus(ctx, waitErr)
+}
+
+func abortDriverProcess(pgid int, wait <-chan error, reason error) (ProcessStatus, error) {
+	_, cleanupErr := stopDriverProcessGroup(pgid, syscall.SIGTERM, wait)
+	return ProcessStatus{}, errors.Join(reason, cleanupErr)
+}
+
+func tryForegroundDriver(terminal driverTerminal, pgid int) (bool, error) {
+	handedOff, err := terminal.handoffIfParentForeground(pgid)
+	if err != nil || !handedOff {
+		return handedOff, err
+	}
+	// Consume a pending SIGTTIN stop before continuing the group.
+	if _, _, err := driverStoppedSignal(pgid); err != nil {
+		return false, fmt.Errorf("consume pre-handoff driver stop: %w", err)
+	}
+	if err := signalDriverProcessGroup(pgid, syscall.SIGCONT); err != nil && !errors.Is(err, syscall.ESRCH) {
+		return false, fmt.Errorf("continue foreground driver process group: %w", err)
+	}
+	return true, nil
+}
+
+func suspendDriverJob(ctx context.Context, terminal driverTerminal, pgid int, stop syscall.Signal) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	if err := terminal.restore(); err != nil {
+		return fmt.Errorf("restore terminal before suspending driver job: %w", err)
+	}
+	// Cancellation may race with the restore ioctl.
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	if err := terminal.suspendParent(stop); err != nil {
+		return fmt.Errorf("suspend driver parent process group: %w", err)
+	}
+	// After SIGCONT, hand off only if the shell foregrounded this job.
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	handedOff, err := tryForegroundDriver(terminal, pgid)
+	if err != nil {
+		return fmt.Errorf("resume driver terminal foreground process group: %w", err)
+	}
+	if !handedOff {
+		if err := signalDriverProcessGroup(pgid, syscall.SIGCONT); err != nil && !errors.Is(err, syscall.ESRCH) {
+			return fmt.Errorf("continue background driver process group: %w", err)
+		}
+	}
+	return nil
+}
+
+func configureDriverProcessGroup(cmd *exec.Cmd, terminal driverTerminal) {
+	if cmd.SysProcAttr == nil {
+		cmd.SysProcAttr = &syscall.SysProcAttr{}
+	} else {
+		attr := *cmd.SysProcAttr
+		cmd.SysProcAttr = &attr
+	}
+	cmd.SysProcAttr.Setpgid = true
+	cmd.SysProcAttr.Pgid = 0
+	if terminal != nil {
+		terminal.configure(cmd.SysProcAttr)
+	}
+}
+
+func driverCancellationSignal(ctx context.Context) syscall.Signal {
+	var cause driverSignalCause
+	if errors.As(context.Cause(ctx), &cause) && cause.signal != 0 {
+		return cause.signal
+	}
+	return syscall.SIGTERM
+}
+
+// stopDriverProcessGroup terminates the driver group, escalating after the grace period.
+func stopDriverProcessGroup(pgid int, initial syscall.Signal, wait <-chan error) (error, error) {
+	state := driverProcessWait{wait: wait, leaderDone: wait == nil}
+	groupDone := !driverProcessGroupExists(pgid)
+	if state.leaderDone && groupDone {
+		return state.leaderErr, nil
+	}
+	var signalErr error
+	if err := signalDriverProcessGroup(pgid, initial); err != nil && !errors.Is(err, syscall.ESRCH) {
+		signalErr = fmt.Errorf("signal driver process group: %w", err)
+	}
+
+	groupDone = state.waitForProcessGroup(pgid, driverProcessGracePeriod)
+	if state.leaderDone && groupDone {
+		return state.leaderErr, signalErr
+	}
+	if err := signalDriverProcessGroup(pgid, syscall.SIGKILL); err != nil && !errors.Is(err, syscall.ESRCH) {
+		signalErr = errors.Join(signalErr, fmt.Errorf("kill driver process group: %w", err))
+	}
+	groupDone = state.waitForProcessGroup(pgid, driverProcessKillWait)
+	if !state.leaderDone {
+		return state.leaderErr, errors.Join(signalErr, fmt.Errorf("driver did not exit after SIGKILL"))
+	}
+	if !groupDone {
+		return state.leaderErr, errors.Join(signalErr, fmt.Errorf("driver descendants did not exit after SIGKILL"))
+	}
+	return state.leaderErr, signalErr
+}
+
+type driverProcessWait struct {
+	wait       <-chan error
+	leaderDone bool
+	leaderErr  error
+}
+
+func (s *driverProcessWait) waitForProcessGroup(pgid int, timeout time.Duration) bool {
+	timer := time.NewTimer(timeout)
+	defer timer.Stop()
+	poll := time.NewTicker(driverProcessPollInterval)
+	defer poll.Stop()
+	for {
+		groupDone := !driverProcessGroupExists(pgid)
+		if s.leaderDone && groupDone {
+			return true
+		}
+		select {
+		case err := <-s.wait:
+			s.leaderDone = true
+			s.leaderErr = err
+			s.wait = nil
+		case <-poll.C:
+		case <-timer.C:
+			return !driverProcessGroupExists(pgid)
+		}
+	}
+}
+
+func signalDriverProcessGroup(pgid int, sig syscall.Signal) error {
+	return syscall.Kill(-pgid, sig)
+}
+
+func driverProcessGroupExists(pgid int) bool {
+	err := syscall.Kill(-pgid, 0)
+	return err == nil || errors.Is(err, syscall.EPERM)
+}
+
+func exitSignal(err *exec.ExitError) (os.Signal, bool) {
+	status, ok := err.Sys().(syscall.WaitStatus)
+	if !ok || !status.Signaled() {
+		return nil, false
+	}
+	return status.Signal(), true
+}

--- a/cmd/internal/projectdriver/process_unix_test.go
+++ b/cmd/internal/projectdriver/process_unix_test.go
@@ -1,0 +1,302 @@
+//go:build darwin || linux
+
+/*
+ * Copyright (c) 2026 The XGo Authors (xgo.dev). All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package projectdriver
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"os/signal"
+	"path/filepath"
+	"strconv"
+	"syscall"
+	"testing"
+	"time"
+)
+
+const driverHelperEnv = "XGO_DRIVER_PROCESS_HELPER"
+
+type driverProcessResult struct {
+	status ProcessStatus
+	err    error
+}
+
+func TestRunDriverProcessForwardsDriverSignal(t *testing.T) {
+	dir := t.TempDir()
+	ready := filepath.Join(dir, "ready")
+	received := filepath.Join(dir, "received")
+	cmd := driverHelperCommand("handle", ready, received, strconv.Itoa(int(syscall.SIGHUP)))
+	boundary := beginDriverSignalBoundary(context.Background())
+	result := make(chan driverProcessResult, 1)
+	go func() {
+		status, err := runDriverProcess(boundary.Context(), cmd)
+		result <- driverProcessResult{status: status, err: err}
+	}()
+	pid := waitForHelperPID(t, ready)
+	t.Cleanup(func() { _ = syscall.Kill(pid, syscall.SIGKILL) })
+
+	boundary.signals <- syscall.SIGHUP
+	got := waitForDriverProcessResult(t, result)
+	var cause driverSignalCause
+	if !errors.As(got.err, &cause) || cause.signal != syscall.SIGHUP {
+		t.Fatalf("runDriverProcess() = (%+v, %v), want SIGHUP cancellation cause", got.status, got.err)
+	}
+	status, err := boundary.Finish(got.status, got.err)
+	if err != nil || !status.Signaled || status.Signal != syscall.SIGHUP {
+		t.Fatalf("Finish(runDriverProcess()) = (%+v, %v), want SIGHUP status", status, err)
+	}
+	if signal := waitForHelperSignal(t, received); signal != syscall.SIGHUP {
+		t.Fatalf("driver received %v, want SIGHUP", signal)
+	}
+}
+
+func TestRunDriverProcessReturnsCancellationAfterGracefulExit(t *testing.T) {
+	dir := t.TempDir()
+	ready := filepath.Join(dir, "ready")
+	received := filepath.Join(dir, "received")
+	cmd := driverHelperCommand("handle", ready, received, strconv.Itoa(int(syscall.SIGTERM)))
+	ctx, cancel := context.WithCancel(context.Background())
+	result := make(chan driverProcessResult, 1)
+	go func() {
+		status, err := runDriverProcess(ctx, cmd)
+		result <- driverProcessResult{status: status, err: err}
+	}()
+	pid := waitForHelperPID(t, ready)
+	t.Cleanup(func() { _ = syscall.Kill(pid, syscall.SIGKILL) })
+
+	cancel()
+	got := waitForDriverProcessResult(t, result)
+	if !errors.Is(got.err, context.Canceled) {
+		t.Fatalf("runDriverProcess() = (%+v, %v), want context cancellation", got.status, got.err)
+	}
+	if signal := waitForHelperSignal(t, received); signal != syscall.SIGTERM {
+		t.Fatalf("driver received %v, want SIGTERM", signal)
+	}
+}
+
+func TestStatusUnlessCanceledRejectsSuccessfulExitAfterCancellation(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	status, err := statusUnlessCanceled(ctx, successStatus())
+	if !errors.Is(err, context.Canceled) || status != (ProcessStatus{}) {
+		t.Fatalf("statusUnlessCanceled() = (%+v, %v), want cancellation", status, err)
+	}
+}
+
+func TestDriverSignalBoundaryRecordsSignalAndCancelsWork(t *testing.T) {
+	boundary := beginDriverSignalBoundary(context.Background())
+	if err := syscall.Kill(os.Getpid(), syscall.SIGTERM); err != nil {
+		t.Fatal(err)
+	}
+	select {
+	case <-boundary.Context().Done():
+	case <-time.After(5 * time.Second):
+		t.Fatal("driver signal boundary did not cancel work")
+	}
+	cause, ok := context.Cause(boundary.Context()).(driverSignalCause)
+	if !ok || cause.signal != syscall.SIGTERM {
+		t.Fatalf("context cause = %#v, want SIGTERM driver signal", context.Cause(boundary.Context()))
+	}
+	status, err := boundary.Finish(ProcessStatus{}, context.Canceled)
+	if err != nil || !status.Signaled || status.Signal != syscall.SIGTERM {
+		t.Fatalf("Finish() = (%+v, %v), want SIGTERM status", status, err)
+	}
+}
+
+func TestRunDriverProcessEscalatesIgnoredCancellation(t *testing.T) {
+	dir := t.TempDir()
+	ready := filepath.Join(dir, "ready")
+	received := filepath.Join(dir, "received")
+	cmd := driverHelperCommand("resist", ready, received, strconv.Itoa(int(syscall.SIGTERM)))
+	ctx, cancel := context.WithCancel(context.Background())
+	result := make(chan driverProcessResult, 1)
+	go func() {
+		status, err := runDriverProcess(ctx, cmd)
+		result <- driverProcessResult{status: status, err: err}
+	}()
+	pid := waitForHelperPID(t, ready)
+	t.Cleanup(func() { _ = syscall.Kill(pid, syscall.SIGKILL) })
+
+	cancel()
+	got := waitForDriverProcessResult(t, result)
+	if got.err != nil || !got.status.Signaled || got.status.Signal != syscall.SIGKILL {
+		t.Fatalf("runDriverProcess() = (%+v, %v), want SIGKILL after grace period", got.status, got.err)
+	}
+	if signal := waitForHelperSignal(t, received); signal != syscall.SIGTERM {
+		t.Fatalf("driver received %v before escalation, want SIGTERM", signal)
+	}
+}
+
+func TestRunDriverProcessCleansDescendantsAfterLeaderExit(t *testing.T) {
+	dir := t.TempDir()
+	childPID := filepath.Join(dir, "child-pid")
+	childReady := filepath.Join(dir, "child-ready")
+	childSignal := filepath.Join(dir, "child-signal")
+	cmd := driverHelperCommand("spawn-descendant", childPID, childReady, childSignal)
+
+	status, err := runDriverProcess(context.Background(), cmd)
+	pid := waitForHelperPID(t, childPID)
+	t.Cleanup(func() { _ = syscall.Kill(pid, syscall.SIGKILL) })
+	if err != nil || status.Signaled || status.Code != 0 {
+		t.Fatalf("runDriverProcess() = (%+v, %v), want successful leader status", status, err)
+	}
+	if signal := waitForHelperSignal(t, childSignal); signal != syscall.SIGTERM {
+		t.Fatalf("descendant received %v before cleanup escalation, want SIGTERM", signal)
+	}
+	if err := syscall.Kill(pid, 0); !errors.Is(err, syscall.ESRCH) {
+		t.Fatalf("same-group descendant %d still exists after driver return: %v", pid, err)
+	}
+}
+
+func TestDriverProcessHelper(t *testing.T) {
+	if os.Getenv(driverHelperEnv) != "1" {
+		return
+	}
+	args := driverHelperArgs()
+	if len(args) == 0 {
+		t.Fatal("missing helper mode")
+	}
+	switch args[0] {
+	case "handle":
+		runDriverSignalHelper(t, args[1:], true)
+	case "resist":
+		runDriverSignalHelper(t, args[1:], false)
+	case "spawn-descendant":
+		if len(args) != 4 {
+			t.Fatalf("spawn-descendant args = %q", args)
+		}
+		child := driverHelperCommand("resist", args[2], args[3], strconv.Itoa(int(syscall.SIGTERM)))
+		if err := child.Start(); err != nil {
+			t.Fatal(err)
+		}
+		if _, err := waitForHelperFile(args[2], 5*time.Second); err != nil {
+			_ = child.Process.Kill()
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(args[1], []byte(strconv.Itoa(child.Process.Pid)), 0o600); err != nil {
+			_ = child.Process.Kill()
+			t.Fatal(err)
+		}
+	default:
+		t.Fatalf("unknown helper mode %q", args[0])
+	}
+}
+
+func runDriverSignalHelper(t *testing.T, args []string, exitAfterSignal bool) {
+	if len(args) != 3 {
+		t.Fatalf("signal helper args = %q", args)
+	}
+	value, err := strconv.Atoi(args[2])
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := syscall.Signal(value)
+	signals := make(chan os.Signal, 8)
+	signal.Notify(signals, want)
+	defer signal.Stop(signals)
+	if err := os.WriteFile(args[0], []byte(strconv.Itoa(os.Getpid())), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	for {
+		received := <-signals
+		unixSignal, ok := received.(syscall.Signal)
+		if !ok {
+			continue
+		}
+		if err := os.WriteFile(args[1], []byte(strconv.Itoa(int(unixSignal))), 0o600); err != nil {
+			t.Fatal(err)
+		}
+		if exitAfterSignal {
+			return
+		}
+	}
+}
+
+func driverHelperCommand(args ...string) *exec.Cmd {
+	commandArgs := []string{"-test.run=^TestDriverProcessHelper$", "--"}
+	commandArgs = append(commandArgs, args...)
+	cmd := exec.Command(os.Args[0], commandArgs...)
+	cmd.Env = append(os.Environ(), driverHelperEnv+"=1")
+	return cmd
+}
+
+func driverHelperArgs() []string {
+	for i, arg := range os.Args {
+		if arg == "--" {
+			return os.Args[i+1:]
+		}
+	}
+	return nil
+}
+
+func waitForDriverProcessResult(t *testing.T, result <-chan driverProcessResult) driverProcessResult {
+	t.Helper()
+	select {
+	case got := <-result:
+		return got
+	case <-time.After(5 * time.Second):
+		t.Fatal("driver process did not return")
+		return driverProcessResult{}
+	}
+}
+
+func waitForHelperPID(t *testing.T, path string) int {
+	t.Helper()
+	data, err := waitForHelperFile(path, 5*time.Second)
+	if err != nil {
+		t.Fatal(err)
+	}
+	pid, err := strconv.Atoi(string(data))
+	if err != nil {
+		t.Fatalf("parse helper pid %q: %v", data, err)
+	}
+	return pid
+}
+
+func waitForHelperSignal(t *testing.T, path string) syscall.Signal {
+	t.Helper()
+	data, err := waitForHelperFile(path, 5*time.Second)
+	if err != nil {
+		t.Fatal(err)
+	}
+	value, err := strconv.Atoi(string(data))
+	if err != nil {
+		t.Fatalf("parse helper signal %q: %v", data, err)
+	}
+	return syscall.Signal(value)
+}
+
+func waitForHelperFile(path string, timeout time.Duration) ([]byte, error) {
+	deadline := time.Now().Add(timeout)
+	for {
+		data, err := os.ReadFile(path)
+		if err == nil {
+			return data, nil
+		}
+		if !errors.Is(err, os.ErrNotExist) {
+			return nil, err
+		}
+		if time.Now().After(deadline) {
+			return nil, fmt.Errorf("timed out waiting for %s", filepath.Base(path))
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+}

--- a/cmd/internal/projectdriver/process_windows.go
+++ b/cmd/internal/projectdriver/process_windows.go
@@ -1,0 +1,241 @@
+//go:build windows
+
+/*
+ * Copyright (c) 2026 The XGo Authors (xgo.dev). All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package projectdriver
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os/exec"
+	"syscall"
+	"time"
+	"unsafe"
+
+	"golang.org/x/sys/windows"
+)
+
+var ntResumeProcess = windows.NewLazySystemDLL("ntdll.dll").NewProc("NtResumeProcess")
+
+const driverJobExitWait = 2 * time.Second
+
+func runDriverProcess(ctx context.Context, cmd *exec.Cmd) (ProcessStatus, error) {
+	if err := ctx.Err(); err != nil {
+		return ProcessStatus{}, err
+	}
+	job, err := createDriverJob()
+	if err != nil {
+		return ProcessStatus{}, err
+	}
+	defer windows.CloseHandle(job)
+	process, err := startDriverInJob(ctx, cmd, job)
+	if err != nil {
+		return ProcessStatus{}, err
+	}
+	return waitForDriverProcess(ctx, cmd, job, process)
+}
+
+func createDriverJob() (windows.Handle, error) {
+	job, err := windows.CreateJobObject(nil, nil)
+	if err != nil {
+		return 0, err
+	}
+	info := windows.JOBOBJECT_EXTENDED_LIMIT_INFORMATION{}
+	info.BasicLimitInformation.LimitFlags = windows.JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE
+	if _, err := windows.SetInformationJobObject(
+		job,
+		windows.JobObjectExtendedLimitInformation,
+		uintptr(unsafe.Pointer(&info)),
+		uint32(unsafe.Sizeof(info)),
+	); err != nil {
+		_ = windows.CloseHandle(job)
+		return 0, err
+	}
+	return job, nil
+}
+
+func startDriverInJob(ctx context.Context, cmd *exec.Cmd, job windows.Handle) (windows.Handle, error) {
+	configureSuspendedDriver(cmd)
+	if err := cmd.Start(); err != nil {
+		return 0, err
+	}
+	// os/exec closes the primary thread handle, so resume through the process.
+	process, err := windows.OpenProcess(
+		windows.PROCESS_SET_QUOTA|windows.PROCESS_TERMINATE|windows.PROCESS_SUSPEND_RESUME,
+		false,
+		uint32(cmd.Process.Pid),
+	)
+	if err != nil {
+		abortSuspendedDriver(cmd, 0)
+		return 0, err
+	}
+	if err := windows.AssignProcessToJobObject(job, process); err != nil {
+		abortSuspendedDriver(cmd, process)
+		_ = windows.CloseHandle(process)
+		return 0, err
+	}
+	if err := ctx.Err(); err != nil {
+		terminateDriverJob(job, process)
+		_ = cmd.Wait()
+		_ = windows.CloseHandle(process)
+		return 0, err
+	}
+	if err := resumeDriverProcess(process); err != nil {
+		terminateDriverJob(job, process)
+		_ = cmd.Wait()
+		_ = windows.CloseHandle(process)
+		return 0, err
+	}
+	return process, nil
+}
+
+func waitForDriverProcess(ctx context.Context, cmd *exec.Cmd, job, process windows.Handle) (ProcessStatus, error) {
+	done := make(chan struct{})
+	watchDone := make(chan struct{})
+	go func() {
+		defer close(watchDone)
+		select {
+		case <-ctx.Done():
+			terminateDriverJob(job, process)
+		case <-done:
+		}
+	}()
+	err := cmd.Wait()
+	close(done)
+	<-watchDone
+	terminateDriverJob(job, process)
+	_ = windows.CloseHandle(process)
+	if cleanupErr := waitForDriverJobExit(job); cleanupErr != nil {
+		return ProcessStatus{}, cleanupErr
+	}
+	// The process and cancellation watcher can become ready at the same time.
+	// Check the context even when the watcher selected the normal-exit branch.
+	return driverExitStatus(ctx, err)
+}
+
+func configureSuspendedDriver(cmd *exec.Cmd) {
+	if cmd.SysProcAttr == nil {
+		cmd.SysProcAttr = &syscall.SysProcAttr{}
+	} else {
+		attr := *cmd.SysProcAttr
+		cmd.SysProcAttr = &attr
+	}
+	cmd.SysProcAttr.CreationFlags |= windows.CREATE_SUSPENDED
+}
+
+func resumeDriverProcess(process windows.Handle) error {
+	if err := ntResumeProcess.Find(); err != nil {
+		return fmt.Errorf("resolve NtResumeProcess: %w", err)
+	}
+	result, _, _ := ntResumeProcess.Call(uintptr(process))
+	status := windows.NTStatus(uint32(result))
+	if status != windows.STATUS_SUCCESS {
+		return fmt.Errorf("resume suspended driver: %w", status)
+	}
+	return nil
+}
+
+func abortSuspendedDriver(cmd *exec.Cmd, process windows.Handle) {
+	if process != 0 {
+		_ = windows.TerminateProcess(process, 1)
+	} else {
+		_ = cmd.Process.Kill()
+	}
+	_ = cmd.Wait()
+}
+
+func terminateDriverJob(job, process windows.Handle) {
+	if err := windows.TerminateJobObject(job, 1); err != nil && process != 0 {
+		_ = windows.TerminateProcess(process, 1)
+	}
+}
+
+func waitForDriverJobExit(job windows.Handle) error {
+	deadline := time.Now().Add(driverJobExitWait)
+	waited := make(map[uintptr]struct{})
+	for {
+		terminateDriverJob(job, 0)
+		pids, err := driverJobProcessIDs(job)
+		if err != nil {
+			return err
+		}
+		found := false
+		for _, pid := range pids {
+			if _, ok := waited[pid]; ok {
+				continue
+			}
+			found = true
+			if err := waitForDriverJobProcess(pid, deadline); err != nil {
+				return err
+			}
+			waited[pid] = struct{}{}
+		}
+		if !found {
+			return nil
+		}
+	}
+}
+
+func waitForDriverJobProcess(pid uintptr, deadline time.Time) error {
+	process, err := windows.OpenProcess(windows.SYNCHRONIZE, false, uint32(pid))
+	if errors.Is(err, windows.ERROR_INVALID_PARAMETER) {
+		return nil
+	}
+	if err != nil {
+		return fmt.Errorf("open driver job process %d: %w", pid, err)
+	}
+	defer windows.CloseHandle(process)
+	remaining := time.Until(deadline)
+	if remaining <= 0 {
+		return errors.New("driver job did not exit after termination")
+	}
+	millis := uint32((remaining + time.Millisecond - 1) / time.Millisecond)
+	result, err := windows.WaitForSingleObject(process, millis)
+	if err != nil {
+		return fmt.Errorf("wait for driver job process %d: %w", pid, err)
+	}
+	if result != windows.WAIT_OBJECT_0 {
+		return errors.New("driver job did not exit after termination")
+	}
+	return nil
+}
+
+func driverJobProcessIDs(job windows.Handle) ([]uintptr, error) {
+	capacity := 16
+	for {
+		buffer := make([]byte, 8+capacity*int(unsafe.Sizeof(uintptr(0))))
+		err := windows.QueryInformationJobObject(
+			job,
+			windows.JobObjectBasicProcessIdList,
+			uintptr(unsafe.Pointer(&buffer[0])),
+			uint32(len(buffer)),
+			nil,
+		)
+		assigned := *(*uint32)(unsafe.Pointer(&buffer[0]))
+		count := *(*uint32)(unsafe.Pointer(&buffer[4]))
+		if count < assigned {
+			capacity = int(assigned)
+			continue
+		}
+		if err != nil {
+			return nil, fmt.Errorf("inspect driver job processes: %w", err)
+		}
+		ids := unsafe.Slice((*uintptr)(unsafe.Pointer(&buffer[8])), int(count))
+		return append([]uintptr(nil), ids...), nil
+	}
+}

--- a/cmd/internal/projectdriver/process_windows_test.go
+++ b/cmd/internal/projectdriver/process_windows_test.go
@@ -1,0 +1,267 @@
+//go:build windows
+
+/*
+ * Copyright (c) 2026 The XGo Authors (xgo.dev). All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package projectdriver
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+	"unsafe"
+
+	"golang.org/x/sys/windows"
+)
+
+func TestConfigureSuspendedDriverPreservesFlags(t *testing.T) {
+	cmd := exec.Command("driver.exe")
+	cmd.SysProcAttr = &windows.SysProcAttr{CreationFlags: windows.CREATE_NO_WINDOW}
+	original := cmd.SysProcAttr
+	configureSuspendedDriver(cmd)
+	if cmd.SysProcAttr == original {
+		t.Fatal("configureSuspendedDriver mutated caller-owned SysProcAttr")
+	}
+	want := uint32(windows.CREATE_NO_WINDOW | windows.CREATE_SUSPENDED)
+	if got := cmd.SysProcAttr.CreationFlags; got != want {
+		t.Fatalf("creation flags = %#x, want %#x", got, want)
+	}
+}
+
+func TestRunDriverProcessWindows(t *testing.T) {
+	if os.Getenv("XGO_TEST_WINDOWS_DRIVER_CHILD") == "1" {
+		inJob, err := currentProcessInJob()
+		if err != nil || !inJob {
+			fmt.Fprintf(os.Stderr, "job=%v err=%v\n", inJob, err)
+			os.Exit(91)
+		}
+		input, err := io.ReadAll(os.Stdin)
+		if err != nil {
+			os.Exit(92)
+		}
+		cwd, err := os.Getwd()
+		if err != nil {
+			os.Exit(93)
+		}
+		fmt.Printf("stdin=%s|env=%s|cwd=%s|args=%s", input, os.Getenv("XGO_TEST_VALUE"), filepath.Base(cwd), strings.Join(os.Args[len(os.Args)-2:], ","))
+		fmt.Fprint(os.Stderr, "driver-stderr")
+		return
+	}
+
+	work := t.TempDir()
+	cmd := exec.Command(os.Args[0], "-test.run=^TestRunDriverProcessWindows$", "--", "a b", `c"d`)
+	cmd.Dir = work
+	cmd.Env = append(os.Environ(), "XGO_TEST_WINDOWS_DRIVER_CHILD=1", "XGO_TEST_VALUE=present")
+	cmd.Stdin = strings.NewReader("driver-stdin")
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout, cmd.Stderr = &stdout, &stderr
+	status, err := runDriverProcess(context.Background(), cmd)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if status.Code != 0 || status.Signaled {
+		t.Fatalf("status = %#v", status)
+	}
+	for _, want := range []string{"stdin=driver-stdin", "env=present", "cwd=" + filepath.Base(work), `args=a b,c"d`} {
+		if !strings.Contains(stdout.String(), want) {
+			t.Fatalf("stdout %q does not contain %q", stdout.String(), want)
+		}
+	}
+	if stderr.String() != "driver-stderr" {
+		t.Fatalf("stderr = %q", stderr.String())
+	}
+}
+
+func TestRunDriverProcessWindowsCleansDescendantAfterLeaderExit(t *testing.T) {
+	testWindowsDriverDescendant(t, false)
+}
+
+func TestRunDriverProcessWindowsCleansDescendantOnCancellation(t *testing.T) {
+	testWindowsDriverDescendant(t, true)
+}
+
+func testWindowsDriverDescendant(t *testing.T, cancelDriver bool) {
+	t.Helper()
+	dir := t.TempDir()
+	pidFile := filepath.Join(dir, "descendant-pid")
+	readyFile := filepath.Join(dir, "descendant-ready")
+	releaseFile := filepath.Join(dir, "release-leader")
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	cmd := exec.Command(os.Args[0], "-test.run=^TestRunDriverProcessWindowsDescendantHelper$")
+	cmd.Env = append(os.Environ(),
+		windowsDriverTreeMode+"=leader",
+		windowsDriverTreePID+"="+pidFile,
+		windowsDriverTreeReady+"="+readyFile,
+		windowsDriverTreeRelease+"="+releaseFile,
+	)
+	result := make(chan windowsDriverResult, 1)
+	go func() {
+		status, err := runDriverProcess(ctx, cmd)
+		result <- windowsDriverResult{status: status, err: err}
+	}()
+
+	pid := waitForWindowsDriverPID(t, pidFile)
+	waitForWindowsDriverFile(t, readyFile)
+	process, err := windows.OpenProcess(windows.SYNCHRONIZE|windows.PROCESS_TERMINATE, false, uint32(pid))
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() {
+		_ = windows.TerminateProcess(process, 1)
+		_ = windows.CloseHandle(process)
+	})
+	if cancelDriver {
+		cancel()
+	} else if err := os.WriteFile(releaseFile, []byte("ready"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	var got windowsDriverResult
+	select {
+	case got = <-result:
+	case <-time.After(15 * time.Second):
+		t.Fatal("driver process did not exit")
+	}
+	if cancelDriver {
+		if got.err != nil && !errors.Is(got.err, context.Canceled) {
+			t.Fatalf("runDriverProcess() cancellation error = %v", got.err)
+		}
+		if got.err == nil && got.status == successStatus() {
+			t.Fatal("canceled driver reported success")
+		}
+	} else if got.err != nil || got.status != successStatus() {
+		t.Fatalf("runDriverProcess() = (%+v, %v), want success", got.status, got.err)
+	}
+	if result, err := windows.WaitForSingleObject(process, 0); err != nil {
+		t.Fatal(err)
+	} else if result != windows.WAIT_OBJECT_0 {
+		t.Fatalf("descendant process remains after driver return (wait result %#x)", result)
+	}
+}
+
+type windowsDriverResult struct {
+	status ProcessStatus
+	err    error
+}
+
+const (
+	windowsDriverTreeMode    = "XGO_TEST_WINDOWS_DRIVER_TREE_MODE"
+	windowsDriverTreePID     = "XGO_TEST_WINDOWS_DRIVER_TREE_PID"
+	windowsDriverTreeReady   = "XGO_TEST_WINDOWS_DRIVER_TREE_READY"
+	windowsDriverTreeRelease = "XGO_TEST_WINDOWS_DRIVER_TREE_RELEASE"
+)
+
+func TestRunDriverProcessWindowsDescendantHelper(t *testing.T) {
+	switch os.Getenv(windowsDriverTreeMode) {
+	case "leader":
+		cmd := exec.Command(os.Args[0], "-test.run=^TestRunDriverProcessWindowsDescendantHelper$")
+		cmd.Env = append(os.Environ(), windowsDriverTreeMode+"=descendant")
+		if err := cmd.Start(); err != nil {
+			os.Exit(91)
+		}
+		pid := strconv.Itoa(cmd.Process.Pid)
+		if err := os.WriteFile(os.Getenv(windowsDriverTreePID), []byte(pid), 0o600); err != nil {
+			os.Exit(92)
+		}
+		if !waitForWindowsDriverPath(os.Getenv(windowsDriverTreeRelease), 15*time.Second) {
+			os.Exit(93)
+		}
+		return
+	case "descendant":
+		inJob, err := currentProcessInJob()
+		if err != nil || !inJob {
+			os.Exit(94)
+		}
+		if err := os.WriteFile(os.Getenv(windowsDriverTreeReady), []byte("ready"), 0o600); err != nil {
+			os.Exit(95)
+		}
+		for {
+			time.Sleep(time.Hour)
+		}
+	}
+}
+
+func waitForWindowsDriverPID(t *testing.T, path string) int {
+	t.Helper()
+	deadline := time.Now().Add(15 * time.Second)
+	var data []byte
+	for time.Now().Before(deadline) {
+		var err error
+		data, err = os.ReadFile(path)
+		if err == nil {
+			if pid, parseErr := strconv.Atoi(strings.TrimSpace(string(data))); parseErr == nil && pid > 0 {
+				return pid
+			}
+		} else if !os.IsNotExist(err) {
+			t.Fatalf("read descendant PID %q: %v", path, err)
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	t.Fatalf("invalid descendant PID %q", data)
+	return 0
+}
+
+func waitForWindowsDriverFile(t *testing.T, path string) {
+	t.Helper()
+	if !waitForWindowsDriverPath(path, 15*time.Second) {
+		t.Fatalf("wait for %q", path)
+	}
+}
+
+func waitForWindowsDriverPath(path string, timeout time.Duration) bool {
+	deadline := time.Now().Add(timeout)
+	for {
+		if _, err := os.Stat(path); err == nil {
+			return true
+		} else if !os.IsNotExist(err) || time.Now().After(deadline) {
+			return false
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+}
+
+func TestStatusUnlessCanceledRejectsSuccessfulExitAfterCancellation(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	status, err := statusUnlessCanceled(ctx, successStatus())
+	if !errors.Is(err, context.Canceled) || status != (ProcessStatus{}) {
+		t.Fatalf("statusUnlessCanceled() = (%+v, %v), want cancellation", status, err)
+	}
+}
+
+func currentProcessInJob() (bool, error) {
+	proc := windows.NewLazySystemDLL("kernel32.dll").NewProc("IsProcessInJob")
+	if err := proc.Find(); err != nil {
+		return false, err
+	}
+	var result int32
+	ok, _, callErr := proc.Call(uintptr(windows.CurrentProcess()), 0, uintptr(unsafe.Pointer(&result)))
+	if ok == 0 {
+		return false, callErr
+	}
+	return result != 0, nil
+}

--- a/cmd/internal/projectdriver/protocol.go
+++ b/cmd/internal/projectdriver/protocol.go
@@ -1,0 +1,118 @@
+/*
+ * Copyright (c) 2026 The XGo Authors (xgo.dev). All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package projectdriver
+
+import (
+	"fmt"
+	"runtime"
+	"strings"
+	"unicode/utf16"
+
+	"github.com/goplus/mod/driverprotocol"
+)
+
+func driverArgs(drv *Driver, act action, policy BuildPolicy, output, finalOutput string, appArgs []string) ([]string, error) {
+	var pack *driverprotocol.Pack
+	if drv.PackDir != "" || drv.PackIndex != "" {
+		pack = &driverprotocol.Pack{Directory: drv.PackDir, IndexFile: drv.PackIndex}
+	}
+	request := driverprotocol.Request{
+		Version: protocolV1,
+		Action:  act,
+		Project: driverprotocol.Project{
+			Dir:           drv.ProjectDir,
+			File:          drv.ProjectFile,
+			ModuleRoot:    drv.ModuleRoot,
+			Extension:     drv.ProjectExt,
+			FullExtension: drv.ProjectFullExt,
+			Pack:          pack,
+		},
+		DriverPackage: drv.DriverPackage,
+		DriverOrigin:  drv.Origin,
+		Declaration:   drv.Declaration,
+		TargetModFile: drv.TargetModFile,
+		Graph: driverprotocol.Graph{
+			GoCommand: drv.Graph.GoCommand,
+			WorkDir:   drv.Graph.WorkDir,
+			GoWork:    drv.Graph.GoWork,
+			Flags:     drv.Graph.goFlags(),
+		},
+		BuildFlags:      policy.protocolFlags(),
+		ApplicationArgs: append([]string(nil), appArgs...),
+	}
+	if output != "" || finalOutput != "" {
+		request.Output = &driverprotocol.BuildOutput{Staging: output, Final: finalOutput}
+	}
+	return driverprotocol.Encode(request)
+}
+
+func validateArgv(executable string, args, env []string) error {
+	if runtime.GOOS == "windows" {
+		// CreateProcessW has a 32,767 UTF-16 code-unit command-line limit. Keep
+		// headroom for quoting performed by os/exec.
+		n := len(utf16.Encode([]rune(executable))) + 1
+		for _, arg := range args {
+			// os/exec may quote the argument and double every backslash before
+			// a quote or the end quote. Two code units per input unit plus the
+			// surrounding syntax is a safe upper bound for CommandLineToArgvW.
+			n += 2*len(utf16.Encode([]rune(arg))) + 3
+		}
+		if n > 30_000 {
+			return ErrDriverArgvTooLarge
+		}
+		envUnits := 1
+		for _, item := range env {
+			envUnits += len(utf16.Encode([]rune(item))) + 1
+		}
+		if envUnits > 32_767 {
+			return ErrDriverArgvTooLarge
+		}
+		return nil
+	}
+	// 128 KiB is below the smallest ARG_MAX supported by XGo's host set and
+	// accounts for both argv and the inherited environment.
+	n := len(executable) + 1
+	for _, arg := range args {
+		n += len(arg) + 1
+	}
+	for _, item := range env {
+		n += len(item) + 1
+	}
+	// execve also consumes one native pointer per argv/env entry. Account for
+	// 64-bit pointers, the largest supported host representation.
+	n += 8 * (len(args) + len(env) + 3)
+	if n > 128<<10 {
+		return ErrDriverArgvTooLarge
+	}
+	return nil
+}
+
+func formatCommandForTrace(executable string, args []string) string {
+	quoted := make([]string, 0, len(args)+1)
+	quoted = append(quoted, quoteForDisplay(executable))
+	for _, arg := range args {
+		quoted = append(quoted, quoteForDisplay(arg))
+	}
+	return strings.Join(quoted, " ")
+}
+
+func quoteForDisplay(value string) string {
+	if value != "" && !strings.ContainsAny(value, " \t\r\n\"'") {
+		return value
+	}
+	return fmt.Sprintf("%q", value)
+}

--- a/cmd/internal/projectdriver/protocol_test.go
+++ b/cmd/internal/projectdriver/protocol_test.go
@@ -1,0 +1,151 @@
+/*
+ * Copyright (c) 2026 The XGo Authors (xgo.dev). All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package projectdriver
+
+import (
+	"errors"
+	"path/filepath"
+	"reflect"
+	"runtime"
+	"strings"
+	"testing"
+
+	"github.com/goplus/mod/xgomod"
+)
+
+func testDriver() *Driver {
+	projectDir := testAbsolutePath("project")
+	frameworkDir := testAbsolutePath("framework")
+	return &Driver{
+		ProjectDir:    projectDir,
+		ProjectFile:   filepath.Join(projectDir, "main.foo"),
+		ModuleRoot:    projectDir,
+		DriverPackage: "example.test/framework/cmd/driver",
+		Origin: ResolvedModule{
+			Selected: ModuleRef{Path: "example.test/framework", Version: "v1.2.3"},
+			Replace: &ModuleRef{
+				Path: frameworkDir, Dir: frameworkDir, GoMod: filepath.Join(frameworkDir, "go.mod"),
+			},
+		},
+		ProjectExt:     ".foo",
+		ProjectFullExt: "*.foo",
+		PackDir:        "payload",
+		PackIndex:      "index.json",
+		Declaration:    xgomod.FileIdentity{Path: filepath.Join(frameworkDir, "gox.mod"), SHA256: strings.Repeat("a", 64)},
+		TargetModFile: xgomod.FileIdentity{
+			Path: filepath.Join(projectDir, "alt.mod"), SHA256: strings.Repeat("b", 64),
+		},
+		Graph: GraphPolicy{
+			GoCommand: testAbsolutePath("go", "bin", executableName("go")),
+			WorkDir:   projectDir,
+			GoWork:    "off",
+			ModMode:   modModeMod,
+			ModFile:   filepath.Join(projectDir, "alt.mod"),
+		},
+	}
+}
+
+func testAbsolutePath(elem ...string) string {
+	root := string(filepath.Separator)
+	if runtime.GOOS == "windows" {
+		root = `C:\`
+	}
+	return filepath.Join(append([]string{root}, elem...)...)
+}
+
+func TestDriverArgsRun(t *testing.T) {
+	drv := testDriver()
+	got, err := driverArgs(drv, actionRun, BuildPolicy{TrimPath: true, Verbose: true, Trace: true, KeepWork: true}, "", "", []string{"", "a b", "--"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := []string{
+		"xgo-driver-v1",
+		"run",
+		"--project-dir=" + drv.ProjectDir,
+		"--project-file=" + drv.ProjectFile,
+		"--module-root=" + drv.ModuleRoot,
+		"--driver-package=example.test/framework/cmd/driver",
+		"--selected-path=example.test/framework",
+		"--selected-version=v1.2.3",
+		"--origin-main=false",
+		"--replace-path=" + drv.Origin.Replace.Path,
+		"--replace-version=",
+		"--replace-dir=" + drv.Origin.Replace.Dir,
+		"--replace-gomod=" + drv.Origin.Replace.GoMod,
+		"--project-ext=.foo",
+		"--project-full-ext=*.foo",
+		"--pack-dir=payload",
+		"--pack-index=index.json",
+		"--declaration-file=" + drv.Declaration.Path,
+		"--declaration-sha256=" + strings.Repeat("a", 64),
+		"--target-modfile=" + drv.TargetModFile.Path,
+		"--target-modfile-sha256=" + strings.Repeat("b", 64),
+		"--go-command=" + drv.Graph.GoCommand,
+		"--graph-work-dir=" + drv.Graph.WorkDir,
+		"--go-work=off",
+		"--graph-flag=-mod=mod",
+		"--graph-flag=-modfile=" + drv.Graph.ModFile,
+		"--build-flag=-v=true",
+		"--build-flag=-x=true",
+		"--build-flag=-work=true",
+		"--build-flag=-trimpath=true",
+		"--", "", "a b", "--",
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("argv = %#v, want %#v", got, want)
+	}
+	joined := strings.Join(got, "\n")
+	if strings.Contains(joined, "selected-dir") || !strings.Contains(joined, "--replace-dir="+drv.Origin.Replace.Dir) {
+		t.Fatalf("replacement identity not preserved:\n%s", joined)
+	}
+}
+
+func TestDriverArgsBuildSelected(t *testing.T) {
+	drv := testDriver()
+	drv.Origin.Replace = nil
+	drv.Origin.Selected.Dir = testAbsolutePath("framework")
+	drv.Origin.Selected.GoMod = filepath.Join(drv.Origin.Selected.Dir, "go.mod")
+	staging := testAbsolutePath("tmp", "stage", "game")
+	final := testAbsolutePath("out", "game")
+	got, err := driverArgs(drv, actionBuild, BuildPolicy{}, staging, final, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	joined := strings.Join(got, "\n")
+	for _, want := range []string{"--selected-dir=" + drv.Origin.Selected.Dir, "--selected-gomod=" + drv.Origin.Selected.GoMod, "--output=" + staging, "--final-output=" + final} {
+		if !strings.Contains(joined, want) {
+			t.Fatalf("missing %q in:\n%s", want, joined)
+		}
+	}
+	if strings.Contains(joined, "--replace-") || strings.Contains(joined, "\n--\n") {
+		t.Fatalf("invalid build argv:\n%s", joined)
+	}
+}
+
+func TestDriverArgsRejectsBuildWithoutOutput(t *testing.T) {
+	if _, err := driverArgs(testDriver(), actionBuild, BuildPolicy{}, "", "", nil); err == nil {
+		t.Fatal("build without output succeeded")
+	}
+}
+
+func TestValidateArgv(t *testing.T) {
+	big := strings.Repeat("x", 256<<10)
+	if err := validateArgv("driver", []string{big}, nil); !errors.Is(err, ErrDriverArgvTooLarge) {
+		t.Fatalf("validateArgv = %v", err)
+	}
+}

--- a/cmd/internal/projectdriver/resolve.go
+++ b/cmd/internal/projectdriver/resolve.go
@@ -1,0 +1,148 @@
+/*
+ * Copyright (c) 2026 The XGo Authors (xgo.dev). All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package projectdriver
+
+import (
+	"context"
+	"errors"
+
+	"github.com/goplus/xgo/env"
+	"github.com/goplus/xgo/x/xgoprojs"
+)
+
+// Resolver owns one invocation's graph and host-build policies.
+type Resolver struct {
+	cwd        string
+	policy     parsedFlags
+	xgoVersion string
+}
+
+var currentXGoVersion = env.Version
+
+// NewResolver snapshots ambient GOFLAGS/GOWORK once. Deferred flags are used
+// only to classify legacy-compatible targets, never to execute a driver.
+func NewResolver(ctx context.Context, cwd string, flags []string) (*Resolver, error) {
+	cwd, err := canonicalExistingDir(cwd)
+	if err != nil {
+		return nil, err
+	}
+	policy, err := preparePolicies(ctx, cwd, flags)
+	if err != nil {
+		return nil, err
+	}
+	return &Resolver{cwd: cwd, policy: policy, xgoVersion: currentXGoVersion()}, nil
+}
+
+// Resolve resolves a parsed XGo target without parsing or generating source.
+func (r *Resolver) Resolve(ctx context.Context, target xgoprojs.Proj) (*Driver, error) {
+	if files, ok := target.(*xgoprojs.FilesProj); ok && len(files.Files) > 1 {
+		return r.resolveFileTargets(ctx, files)
+	}
+	input, err := r.classifyTarget(ctx, target)
+	if err != nil {
+		return nil, err
+	}
+	return r.resolveClassifiedTarget(ctx, input)
+}
+
+func (r *Resolver) resolveFileTargets(ctx context.Context, target *xgoprojs.FilesProj) (*Driver, error) {
+	for _, name := range target.Files {
+		input, err := r.classifyFileTarget(name)
+		if err != nil {
+			return nil, err
+		}
+		input.multiFile = true
+		driver, err := r.resolveClassifiedTarget(ctx, input)
+		if !errors.Is(err, ErrNotHandled) {
+			return driver, err
+		}
+	}
+	return nil, ErrNotHandled
+}
+
+func (r *Resolver) resolveClassifiedTarget(ctx context.Context, input targetResolution) (*Driver, error) {
+	policy := r.policy.graph
+	policy.WorkDir = input.graphWorkDir
+	graph, err := r.resolveTargetGraph(ctx, input.projectDir, input.graph, policy, input.recursive)
+	if err != nil {
+		return nil, err
+	}
+	driver, err := r.buildResolvedDriver(input, graph, policy)
+	if err != nil {
+		return nil, err
+	}
+	if err := r.policy.validateDriver(); err != nil {
+		return nil, err
+	}
+	driver.buildPolicy = r.policy.build
+	return driver, nil
+}
+
+func (r *Resolver) resolveTargetGraph(ctx context.Context, projectDir string, graph *effectiveGraph, policy GraphPolicy, recursive bool) (*effectiveGraph, error) {
+	if graph != nil {
+		if graph.files == nil || !graph.files.hasOverlay() {
+			return graph, nil
+		}
+		hasDriver, err := overlayDriverProjectMatch(projectDir, graph, recursive)
+		if err != nil {
+			return nil, err
+		}
+		if !hasDriver {
+			return nil, ErrNotHandled
+		}
+		return nil, unsupportedOverlayError(policy.Overlay)
+	}
+	// An overlay may change both the module graph and class metadata.
+	if overlay := policy.Overlay; overlay != "" {
+		overlayGraph, err := loadEffectiveGraph(ctx, projectDir, policy)
+		if err != nil {
+			if errors.Is(err, errNoGoModule) {
+				return nil, ErrNotHandled
+			}
+			return nil, err
+		}
+		hasDriver, err := overlayDriverProjectMatch(projectDir, overlayGraph, recursive)
+		if err != nil {
+			return nil, err
+		}
+		if !hasDriver {
+			return nil, ErrNotHandled
+		}
+		return nil, unsupportedOverlayError(overlay)
+	}
+	preflightModule, _, hasClass, vendor, err := r.preflightClassMetadata(ctx, projectDir)
+	if err != nil {
+		if errors.Is(err, errNoGoModule) {
+			return nil, ErrNotHandled
+		}
+		return nil, err
+	}
+	if !hasClass {
+		return nil, ErrNotHandled
+	}
+	if vendor {
+		hasDriver, err := r.matchVendorModule(projectDir, preflightModule, recursive)
+		if err != nil {
+			return nil, err
+		}
+		if !hasDriver {
+			return nil, ErrNotHandled
+		}
+		return nil, vendorUnsupportedError(string(r.policy.graph.ModMode))
+	}
+	return loadEffectiveGraph(ctx, projectDir, r.policy.graph)
+}

--- a/cmd/internal/projectdriver/resolve_driver.go
+++ b/cmd/internal/projectdriver/resolve_driver.go
@@ -1,0 +1,184 @@
+/*
+ * Copyright (c) 2026 The XGo Authors (xgo.dev). All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package projectdriver
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+
+	"github.com/goplus/mod/xgomod"
+)
+
+func (r *Resolver) buildResolvedDriver(target targetResolution, graph *effectiveGraph, policy GraphPolicy) (*Driver, error) {
+	module, hasClass, err := loadResolvedClasses(graph)
+	if err != nil {
+		return nil, err
+	}
+	if !hasClass {
+		return nil, ErrNotHandled
+	}
+	projectFile, info, err := resolveDriverProject(target, module)
+	if err != nil {
+		return nil, err
+	}
+	if err := checkDriverXGoVersion(info.RequiredXGo, r.xgoVersion); err != nil {
+		return nil, err
+	}
+	project := info.Project
+	if project.Driver.Protocol != protocolV1 {
+		return nil, fmt.Errorf("unsupported driver protocol %q", project.Driver.Protocol)
+	}
+	packDir, packIndex, err := validatePack(target.projectDir, project.Pack)
+	if err != nil {
+		return nil, err
+	}
+	origin := *info.Origin
+	declaration, err := declaringMetadata(origin, info.Declaration)
+	if err != nil {
+		return nil, err
+	}
+	if os.Getenv("XGO_DRIVER") == "off" {
+		return nil, ErrDriverDisabled
+	}
+	if os.Getenv(driverGuardEnv) != "" {
+		return nil, ErrDriverRecursive
+	}
+	return &Driver{
+		DefaultExecName: defaultExecutableName(target.projectDir, target.targetImportPath),
+		ProjectDir:      target.projectDir,
+		ProjectFile:     projectFile,
+		ModuleRoot:      graph.Target.Effective().Dir,
+		DriverPackage:   project.Driver.Package,
+		Origin:          origin,
+		ProjectExt:      project.Ext,
+		ProjectFullExt:  project.FullExt,
+		PackDir:         packDir,
+		PackIndex:       packIndex,
+		Declaration:     declaration,
+		TargetModFile:   graph.TargetModFile,
+		Graph:           policy,
+	}, nil
+}
+
+func resolveDriverProject(target targetResolution, module *xgomod.Module) (string, *xgomod.ProjectInfo, error) {
+	if target.recursive {
+		hasDriver, err := patternContainsDriverProject(target.projectDir, module)
+		if err != nil {
+			return "", nil, err
+		}
+		if !hasDriver {
+			return "", nil, ErrNotHandled
+		}
+		return "", nil, fmt.Errorf("driver v1 does not support %s", target.unsupportedForm)
+	}
+
+	projectFile, info, candidates, err := findProjectFile(target.projectDir, module)
+	if err != nil {
+		return "", nil, err
+	}
+	if info == nil || info.Project.Driver == nil {
+		return "", nil, ErrNotHandled
+	}
+	if candidates != 1 {
+		return "", nil, fmt.Errorf("driver-backed project directory %q contains %d project files; exactly one is required", target.projectDir, candidates)
+	}
+	if target.multiFile {
+		return "", nil, fmt.Errorf("driver v1 does not support multiple source-file targets")
+	}
+	if target.fileError != nil {
+		return "", nil, target.fileError
+	}
+	if err := validateDriverFileTarget(target, projectFile); err != nil {
+		return "", nil, err
+	}
+	if info.Origin == nil {
+		return "", nil, fmt.Errorf("driver-backed project %q has no module provenance", projectFile)
+	}
+	return projectFile, info, nil
+}
+
+func validateDriverFileTarget(target targetResolution, projectFile string) error {
+	if target.expectedFile != "" {
+		if target.expectedFileInfo != nil {
+			current, err := os.Lstat(target.expectedFile)
+			if err != nil || current.Mode()&os.ModeSymlink != 0 || !current.Mode().IsRegular() || !os.SameFile(target.expectedFileInfo, current) {
+				return fmt.Errorf("driver file target %q changed during classification", target.original)
+			}
+		}
+		same, err := sameFile(target.expectedFile, projectFile)
+		if err != nil || !same {
+			return fmt.Errorf("driver file target %q is not the unique project file %q", target.original, projectFile)
+		}
+	}
+	return nil
+}
+
+func declaringMetadata(origin ResolvedModule, snapshot xgomod.FileIdentity) (fileIdentity, error) {
+	dir := origin.Effective().Dir
+	base := filepath.Base(snapshot.Path)
+	if snapshot.Path == "" || snapshot.SHA256 == "" || filepath.Dir(snapshot.Path) != dir || (base != "gox.mod" && base != "gop.mod") {
+		return fileIdentity{}, fmt.Errorf("driver origin %q has an invalid declaring metadata snapshot", origin.Selected.Path)
+	}
+	if err := verifyFileSnapshot("declaring metadata", snapshot); err != nil {
+		return fileIdentity{}, err
+	}
+	return fileIdentity(snapshot), nil
+}
+
+func verifyTargetModFile(snapshot xgomod.FileIdentity) error {
+	if snapshot.Path == "" || snapshot.SHA256 == "" || !filepath.IsAbs(snapshot.Path) {
+		return fmt.Errorf("invalid target modfile snapshot")
+	}
+	return verifyFileSnapshot("target modfile", snapshot)
+}
+
+func verifyFileSnapshot(label string, snapshot xgomod.FileIdentity) error {
+	path := snapshot.Path
+	before, err := os.Lstat(path)
+	if err != nil {
+		return fmt.Errorf("%s %q: %w", label, path, err)
+	}
+	if before.Mode()&os.ModeSymlink != 0 || !before.Mode().IsRegular() {
+		return fmt.Errorf("%s %q is not a regular non-symlink file", label, path)
+	}
+	file, err := os.Open(path)
+	if err != nil {
+		return fmt.Errorf("%s %q: %w", label, path, err)
+	}
+	data, readErr := io.ReadAll(file)
+	opened, statErr := file.Stat()
+	closeErr := file.Close()
+	if readErr != nil {
+		return readErr
+	}
+	if statErr != nil {
+		return statErr
+	}
+	if closeErr != nil {
+		return closeErr
+	}
+	after, err := os.Lstat(path)
+	if err != nil || !os.SameFile(before, opened) || !os.SameFile(opened, after) || !after.Mode().IsRegular() {
+		return fmt.Errorf("%s %q changed after discovery", label, path)
+	}
+	if got := sha256Bytes(data); got != snapshot.SHA256 {
+		return fmt.Errorf("%s %q changed after discovery", label, path)
+	}
+	return nil
+}

--- a/cmd/internal/projectdriver/resolve_overlay.go
+++ b/cmd/internal/projectdriver/resolve_overlay.go
@@ -1,0 +1,177 @@
+/*
+ * Copyright (c) 2026 The XGo Authors (xgo.dev). All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package projectdriver
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/goplus/mod/modfile"
+)
+
+// resolveOverlayLocalTarget classifies overlay-only local targets.
+// xgoprojs may parse both files and directories as DirProj.
+func (r *Resolver) resolveOverlayLocalTarget(ctx context.Context, candidate string, recursive bool) (string, *effectiveGraph, error) {
+	graph, err := loadEffectiveGraph(ctx, r.cwd, r.policy.graph)
+	if err != nil {
+		if errors.Is(err, errNoGoModule) {
+			return "", nil, ErrNotHandled
+		}
+		return "", nil, err
+	}
+	logical := overlayPath(r.cwd, candidate)
+	projectDir, dirErr := graph.files.canonicalDir(logical)
+	if dirErr != nil {
+		if recursive {
+			if os.IsNotExist(dirErr) {
+				return "", nil, ErrNotHandled
+			}
+			return "", nil, fmt.Errorf("overlay local target %q: %w", candidate, dirErr)
+		}
+		visible, fileErr := graph.files.regularFileVisible(logical)
+		if fileErr != nil {
+			return "", nil, fmt.Errorf("overlay local target %q: %w", candidate, fileErr)
+		}
+		if !visible {
+			if !os.IsNotExist(dirErr) {
+				return "", nil, fmt.Errorf("overlay local target %q: %w", candidate, dirErr)
+			}
+			return "", nil, ErrNotHandled
+		}
+		projectDir, err = graph.files.canonicalDir(filepath.Dir(logical))
+		if err != nil {
+			return "", nil, fmt.Errorf("overlay local file target %q: %w", candidate, err)
+		}
+	}
+	targetModule, err := selectTargetModule(projectDir, graph.Modules)
+	if err != nil {
+		return "", nil, err
+	}
+	graph, err = retargetEffectiveGraph(ctx, graph, targetModule, r.policy.graph)
+	if err != nil {
+		return "", nil, err
+	}
+	return projectDir, graph, nil
+}
+
+func classModuleMarked(classModules []ResolvedModule, modulePath string) bool {
+	for _, module := range classModules {
+		if module.Selected.Path == modulePath {
+			return true
+		}
+	}
+	return false
+}
+
+// overlayDriverProjectMatch classifies against overlay metadata only.
+// Driver v1 rejects a positive overlay match before execution.
+func overlayDriverProjectMatch(projectDir string, graph *effectiveGraph, recursive bool) (bool, error) {
+	if graph == nil || graph.files == nil || !graph.files.hasOverlay() {
+		return false, fmt.Errorf("overlay classification requires an effective graph file view")
+	}
+	projects, err := overlayDriverProjects(graph)
+	if err != nil {
+		return false, err
+	}
+	if len(projects) == 0 {
+		return false, nil
+	}
+	if recursive {
+		return overlayWalkDriverProjects(projectDir, projects, graph.files)
+	}
+	names, err := graph.files.regularFileNames(projectDir)
+	if err != nil {
+		return false, err
+	}
+	for _, name := range names {
+		if driverProjectMatches(projects, name) {
+			return true, nil
+		}
+	}
+	return false, nil
+}
+
+func overlayDriverProjects(graph *effectiveGraph) ([]*modfile.Project, error) {
+	target := graph.Target.Effective()
+	loaded, err := loadDriverModuleView(graph.TargetModFile.Path, filepath.Join(target.Dir, "gox.mod"), graph.files)
+	if err != nil {
+		return nil, fmt.Errorf("load overlaid target metadata: %w", err)
+	}
+	projects := append([]*modfile.Project(nil), loaded.Projects()...)
+	for _, class := range graph.ClassModules {
+		effective := class.Effective()
+		classModule, loadErr := loadDriverModuleView(effective.GoMod, filepath.Join(effective.Dir, "gox.mod"), graph.files)
+		if loadErr != nil {
+			return nil, fmt.Errorf("load overlaid class module %q metadata: %w", class.Selected.Path, loadErr)
+		}
+		projects = append(projects, classModule.Projects()...)
+	}
+	return projects, nil
+}
+
+func overlayWalkDriverProjects(root string, projects []*modfile.Project, view *graphFileView) (bool, error) {
+	root = overlayPath(view.workDir, root)
+	visited := make(map[string]struct{})
+	var walk func(string) error
+	walk = func(current string) error {
+		if _, ok := visited[current]; ok {
+			return nil
+		}
+		visited[current] = struct{}{}
+		names, err := view.regularFileNames(current)
+		if err != nil {
+			return err
+		}
+		for _, name := range names {
+			if driverProjectMatches(projects, name) {
+				return errDriverProjectInPattern
+			}
+		}
+		dirs, err := view.directoryNames(current)
+		if err != nil {
+			return err
+		}
+		for _, name := range dirs {
+			if name == "vendor" || name == "testdata" || strings.HasPrefix(name, ".") || strings.HasPrefix(name, "_") {
+				continue
+			}
+			child := filepath.Join(current, name)
+			if isGoMod, err := view.regularFileVisible(filepath.Join(child, "go.mod")); err != nil {
+				return err
+			} else if isGoMod {
+				continue
+			}
+			if err := walk(child); err != nil {
+				return err
+			}
+		}
+		return nil
+	}
+	err := walk(root)
+	if errors.Is(err, errDriverProjectInPattern) {
+		return true, nil
+	}
+	return false, err
+}
+
+func unsupportedOverlayError(path string) error {
+	return fmt.Errorf("driver v1 does not support flag -overlay=%s", path)
+}

--- a/cmd/internal/projectdriver/resolve_overlay_test.go
+++ b/cmd/internal/projectdriver/resolve_overlay_test.go
@@ -1,0 +1,184 @@
+/*
+ * Copyright (c) 2026 The XGo Authors (xgo.dev). All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package projectdriver
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/goplus/xgo/x/xgoprojs"
+)
+
+func TestResolveOverlayClassifiesDriverBeforePhysicalPreflight(t *testing.T) {
+	if testing.Short() {
+		t.Skip("invokes the host Go command")
+	}
+	t.Setenv("GOWORK", "off")
+	root := t.TempDir()
+	app := filepath.Join(root, "app")
+	project := filepath.Join(app, "game")
+	framework := filepath.Join(root, "framework")
+	mustMkdirAll(t, project)
+	mustMkdirAll(t, filepath.Join(framework, "cmd", "driver"))
+	mustWriteFile(t, filepath.Join(app, "go.mod"), "module example.test/app\n\ngo 1.25\n")
+	mustWriteFile(t, filepath.Join(framework, "go.mod"), "module example.test/framework\n\ngo 1.25\n")
+	mustWriteFile(t, filepath.Join(framework, "gox.mod"), `xgo 1.8
+project main.foo Game example.test/framework
+driver v1 example.test/framework/cmd/driver
+`)
+	mustWriteFile(t, filepath.Join(framework, "cmd", "driver", "main.go"), fakeDriverSource)
+	mustWriteFile(t, filepath.Join(project, "main.foo"), "// overlaid driver-backed project\n")
+	overlayMod := filepath.Join(root, "overlay.mod")
+	mustWriteFile(t, overlayMod, `module example.test/app
+
+go 1.25
+
+require example.test/framework v1.2.3 //xgo:class
+
+replace example.test/framework => ../framework
+`)
+	overlayFile := filepath.Join(root, "overlay.json")
+	canonicalApp, err := canonicalExistingDir(app)
+	if err != nil {
+		t.Fatal(err)
+	}
+	overlayData, err := json.Marshal(struct {
+		Replace map[string]string `json:"Replace"`
+	}{Replace: map[string]string{filepath.Join(canonicalApp, "go.mod"): overlayMod}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	mustWriteFile(t, overlayFile, string(overlayData))
+	resolver, err := NewResolver(context.Background(), app, []string{"-overlay=" + overlayFile})
+	if err != nil {
+		t.Fatal(err)
+	}
+	canonicalProject, err := canonicalExistingDir(project)
+	if err != nil {
+		t.Fatal(err)
+	}
+	graph, graphErr := loadEffectiveGraph(context.Background(), canonicalProject, resolver.policy.graph)
+	if graphErr == nil {
+		matched, matchErr := overlayDriverProjectMatch(canonicalProject, graph, false)
+		if matchErr != nil || !matched {
+			t.Fatalf("overlay classification = %v, %v; want driver match", matched, matchErr)
+		}
+	} else {
+		t.Fatalf("load overlay graph: %v", graphErr)
+	}
+	_, err = resolver.Resolve(context.Background(), &xgoprojs.DirProj{Dir: project})
+	if err == nil || errors.Is(err, ErrNotHandled) || !strings.Contains(err.Error(), "-overlay") {
+		t.Fatalf("overlay driver Resolve() = %v, want explicit overlay rejection", err)
+	}
+	_, err = resolver.Resolve(context.Background(), &xgoprojs.PkgPathProj{Path: "example.test/app/game"})
+	if err == nil || errors.Is(err, ErrNotHandled) || !strings.Contains(err.Error(), "-overlay") {
+		t.Fatalf("overlay driver package Resolve() = %v, want explicit overlay rejection", err)
+	}
+}
+
+func TestResolveOverlayLegacyTargetRemainsUnhandled(t *testing.T) {
+	if testing.Short() {
+		t.Skip("invokes the host Go command")
+	}
+	t.Setenv("GOWORK", "off")
+	root := t.TempDir()
+	app := filepath.Join(root, "app")
+	mustMkdirAll(t, app)
+	mustWriteFile(t, filepath.Join(app, "go.mod"), "module example.test/app\n\ngo 1.25\n")
+	mustWriteFile(t, filepath.Join(app, "main.go"), "package main\nfunc main() {}\n")
+	overlayFile := filepath.Join(root, "overlay.json")
+	overlayData, err := json.Marshal(struct {
+		Replace map[string]string `json:"Replace"`
+	}{Replace: map[string]string{filepath.Join(app, "main.go"): ""}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	mustWriteFile(t, overlayFile, string(overlayData))
+	resolver, err := NewResolver(context.Background(), app, []string{"-overlay=" + overlayFile})
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, err = resolver.Resolve(context.Background(), &xgoprojs.DirProj{Dir: app})
+	if !errors.Is(err, ErrNotHandled) {
+		t.Fatalf("overlay legacy Resolve() = %v, want ErrNotHandled", err)
+	}
+}
+
+func TestResolveOverlayTargetsWithSyntheticDirectory(t *testing.T) {
+	if testing.Short() {
+		t.Skip("invokes the host Go command")
+	}
+	t.Setenv("GOWORK", "off")
+	root := t.TempDir()
+	app := filepath.Join(root, "app")
+	actual := filepath.Join(root, "overlay-files")
+	mustMkdirAll(t, app)
+	mustMkdirAll(t, actual)
+	mustWriteFile(t, filepath.Join(app, "go.mod"), "module example.test/app\n\ngo 1.25\n")
+	mustWriteFile(t, filepath.Join(app, "gox.mod"), `xgo 1.8
+project main.foo Game example.test/app
+driver v1 example.test/app/cmd/driver
+`)
+	mustWriteFile(t, filepath.Join(actual, "main.go"), "package game\n")
+	mustWriteFile(t, filepath.Join(actual, "main.foo"), "// overlaid driver-backed project\n")
+	overlayFile := filepath.Join(root, "overlay.json")
+	canonicalApp, err := canonicalExistingDir(app)
+	if err != nil {
+		t.Fatal(err)
+	}
+	canonicalProject := filepath.Join(canonicalApp, "game")
+	data, err := json.Marshal(struct {
+		Replace map[string]string `json:"Replace"`
+	}{Replace: map[string]string{
+		filepath.Join(canonicalProject, "main.go"):  filepath.Join(actual, "main.go"),
+		filepath.Join(canonicalProject, "main.foo"): filepath.Join(actual, "main.foo"),
+	}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	mustWriteFile(t, overlayFile, string(data))
+	resolver, err := NewResolver(context.Background(), app, []string{"-overlay=" + overlayFile})
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, arg := range []string{
+		canonicalProject,
+		filepath.Join(canonicalProject, "main.foo"),
+		filepath.Join(canonicalProject, "..."),
+	} {
+		target, next, parseErr := xgoprojs.ParseOne(arg)
+		if parseErr != nil || len(next) != 0 {
+			t.Fatalf("ParseOne(%q) = (%T, %v, %v)", arg, target, next, parseErr)
+		}
+		_, resolveErr := resolver.Resolve(context.Background(), target)
+		if resolveErr == nil || errors.Is(resolveErr, ErrNotHandled) || !strings.Contains(resolveErr.Error(), "-overlay") {
+			t.Fatalf("overlay synthetic local target %q Resolve() = %v, want explicit overlay rejection", arg, resolveErr)
+		}
+	}
+	_, err = resolver.Resolve(context.Background(), &xgoprojs.PkgPathProj{Path: "example.test/app/game"})
+	if err == nil || errors.Is(err, ErrNotHandled) || !strings.Contains(err.Error(), "-overlay") {
+		t.Fatalf("overlay synthetic package Resolve() = %v, want explicit overlay rejection", err)
+	}
+	_, err = resolver.Resolve(context.Background(), &xgoprojs.PkgPathProj{Path: "example.test/app/..."})
+	if err == nil || errors.Is(err, ErrNotHandled) || !strings.Contains(err.Error(), "-overlay") {
+		t.Fatalf("overlay synthetic package pattern Resolve() = %v, want explicit overlay rejection", err)
+	}
+}

--- a/cmd/internal/projectdriver/resolve_package.go
+++ b/cmd/internal/projectdriver/resolve_package.go
@@ -1,0 +1,102 @@
+/*
+ * Copyright (c) 2026 The XGo Authors (xgo.dev). All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package projectdriver
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/goplus/mod/modload"
+	"github.com/goplus/xgo/x/xgoprojs"
+)
+
+func (r *Resolver) classifyPackageTarget(ctx context.Context, target *xgoprojs.PkgPathProj) (targetResolution, error) {
+	result := targetResolution{
+		targetImportPath: target.Path,
+		graphWorkDir:     r.cwd,
+	}
+	lookupPath := target.Path
+	if strings.Contains(lookupPath, "@") {
+		hasDriver, err := r.versionedPackageHasDriver(ctx, lookupPath)
+		if err != nil {
+			return targetResolution{}, err
+		}
+		if !hasDriver {
+			return targetResolution{}, ErrNotHandled
+		}
+		return targetResolution{}, fmt.Errorf("driver v1 does not support package target containing @version")
+	}
+	if hasRecursivePattern(lookupPath) {
+		result.unsupportedForm = "package pattern containing ..."
+		result.recursive = true
+		lookupPath = trimRecursivePattern(lookupPath)
+	}
+
+	hasOverlay := r.policy.graph.Overlay != ""
+	var (
+		preflightModule modload.Module
+		preflightGoMod  string
+		callerHasClass  bool
+		vendor          bool
+	)
+	if !hasOverlay {
+		var preflightErr error
+		preflightModule, preflightGoMod, callerHasClass, vendor, preflightErr = r.preflightClassMetadata(ctx, r.cwd)
+		if preflightErr != nil && !errors.Is(preflightErr, errNoGoModule) {
+			return targetResolution{}, preflightErr
+		}
+		if vendor {
+			if !callerHasClass && r.policy.graph.GoWork == "off" {
+				return targetResolution{}, ErrNotHandled
+			}
+			hasDriver, probeErr := r.probeVendorPackage(ctx, preflightGoMod, preflightModule, lookupPath, result.recursive)
+			if probeErr != nil {
+				return targetResolution{}, probeErr
+			}
+			if hasDriver {
+				return targetResolution{}, vendorUnsupportedError(string(r.policy.graph.ModMode))
+			}
+			return targetResolution{}, ErrNotHandled
+		}
+	}
+
+	callerGraph, err := loadEffectiveGraph(ctx, r.cwd, r.policy.graph)
+	if err != nil {
+		if errors.Is(err, errNoGoModule) && !callerHasClass && !hasOverlay {
+			return targetResolution{}, ErrNotHandled
+		}
+		return targetResolution{}, err
+	}
+	projectDir, targetModule, err := resolvePackageDirectory(ctx, callerGraph, lookupPath, r.cwd, r.policy.graph)
+	if err != nil {
+		if callerHasClass || hasOverlay {
+			return targetResolution{}, err
+		}
+		return targetResolution{}, ErrNotHandled
+	}
+	if !targetModule.Main && !classModuleMarked(callerGraph.ClassModules, targetModule.Selected.Path) {
+		return targetResolution{}, ErrNotHandled
+	}
+	result.projectDir = projectDir
+	result.graph, err = retargetEffectiveGraph(ctx, callerGraph, targetModule, r.policy.graph)
+	if err != nil {
+		return targetResolution{}, err
+	}
+	return result, nil
+}

--- a/cmd/internal/projectdriver/resolve_policy_test.go
+++ b/cmd/internal/projectdriver/resolve_policy_test.go
@@ -1,0 +1,544 @@
+/*
+ * Copyright (c) 2026 The XGo Authors (xgo.dev). All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package projectdriver
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/goplus/mod/xgomod"
+	"github.com/goplus/xgo/x/xgoprojs"
+)
+
+func TestLoadDriverModulePropagatesOptionalMetadataReadErrors(t *testing.T) {
+	dir := t.TempDir()
+	goMod := filepath.Join(dir, "go.mod")
+	goxMod := filepath.Join(dir, "gox.mod")
+	mustWriteFile(t, goMod, "module example.test/app\n\ngo 1.25\n")
+	mustMkdirAll(t, goxMod)
+	// A valid legacy fallback must not mask a non-NotExist error from gox.mod.
+	mustWriteFile(t, filepath.Join(dir, "gop.mod"), "gop 1.8\nproject main.foo Game example.test/app\n")
+	if _, err := loadDriverModule(goMod, goxMod); err == nil || !strings.Contains(err.Error(), "gox.mod") {
+		t.Fatalf("loadDriverModule() = %v, want explicit gox.mod read error", err)
+	}
+}
+
+func TestLoadDriverModuleFallsBackToGopModWhenGoxModIsAbsent(t *testing.T) {
+	dir := t.TempDir()
+	goMod := filepath.Join(dir, "go.mod")
+	gopMod := filepath.Join(dir, "gop.mod")
+	mustWriteFile(t, goMod, "module example.test/app\n\ngo 1.25\n")
+	mustWriteFile(t, gopMod, "gop 1.1\nproject main.foo Game example.test/app\n")
+	loaded, err := loadDriverModule(goMod, filepath.Join(dir, "gox.mod"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !loaded.HasProject() || loaded.GoxModIdentity().Path != gopMod {
+		t.Fatalf("gop.mod fallback identity = %#v", loaded.GoxModIdentity())
+	}
+}
+
+func TestResolvePropagatesOptionalMetadataReadErrors(t *testing.T) {
+	if testing.Short() {
+		t.Skip("invokes the host Go command")
+	}
+	dir := t.TempDir()
+	mustWriteFile(t, filepath.Join(dir, "go.mod"), "module example.test/app\n\ngo 1.25\n")
+	mustMkdirAll(t, filepath.Join(dir, "gox.mod"))
+	mustWriteFile(t, filepath.Join(dir, "main.foo"), "// project source\n")
+	t.Setenv("GOWORK", "off")
+	resolver, err := NewResolver(context.Background(), dir, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, err = resolver.Resolve(context.Background(), &xgoprojs.DirProj{Dir: dir})
+	if err == nil || errors.Is(err, ErrNotHandled) || !strings.Contains(err.Error(), "gox.mod") {
+		t.Fatalf("Resolve() = %v, want explicit gox.mod read error", err)
+	}
+}
+
+func TestResolvePackageTargetRejectsUnmarkedDependencyDriver(t *testing.T) {
+	if testing.Short() {
+		t.Skip("invokes the host Go command")
+	}
+	fixture := newDriverFixture(t)
+	dependencyProject := filepath.Join(fixture.framework, "example")
+	mustMkdirAll(t, filepath.Join(dependencyProject, "pack"))
+	mustWriteFile(t, filepath.Join(dependencyProject, "main.foo"), "// dependency project\n")
+	mustWriteFile(t, filepath.Join(dependencyProject, "pack", "index.data"), "{}\n")
+
+	goModPath := filepath.Join(fixture.app, "go.mod")
+	goMod, err := os.ReadFile(goModPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	goMod = bytes.Replace(goMod, []byte(" //xgo:class"), nil, 1)
+	if err := os.WriteFile(goModPath, goMod, 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	resolver := fixture.resolver(t)
+	_, err = resolver.Resolve(context.Background(), &xgoprojs.PkgPathProj{Path: "example.test/framework/example"})
+	if !errors.Is(err, ErrNotHandled) {
+		t.Fatalf("unmarked dependency driver = %v, want ErrNotHandled", err)
+	}
+}
+
+func TestResolveOrdinaryGoSubpackageInsideDriverModuleUsesLegacyPath(t *testing.T) {
+	if testing.Short() {
+		t.Skip("invokes the host Go command")
+	}
+	fixture := newDriverFixture(t)
+	ordinary := filepath.Join(fixture.framework, "ordinary")
+	mustMkdirAll(t, ordinary)
+	mustWriteFile(t, filepath.Join(ordinary, "main.go"), "package ordinary\n")
+	resolver := fixture.resolver(t)
+	_, err := resolver.Resolve(context.Background(), &xgoprojs.PkgPathProj{Path: "example.test/framework/ordinary"})
+	if !errors.Is(err, ErrNotHandled) {
+		t.Fatalf("ordinary Go subpackage = %v", err)
+	}
+}
+
+func TestUnsupportedPatternOnlyRejectsMatchedDriverTarget(t *testing.T) {
+	if testing.Short() {
+		t.Skip("invokes the host Go command")
+	}
+	fixture := newDriverFixture(t)
+	legacy := filepath.Join(fixture.app, "legacy")
+	mustMkdirAll(t, legacy)
+	mustWriteFile(t, filepath.Join(legacy, "main.go"), "package main\nfunc main() {}\n")
+	nested := filepath.Join(legacy, "nested")
+	mustMkdirAll(t, nested)
+	mustWriteFile(t, filepath.Join(nested, "go.mod"), "module example.test/nested\n\ngo 1.25\n")
+	mustWriteFile(t, filepath.Join(nested, "main.foo"), "// nested driver-backed project must be outside the pattern\n")
+	resolver := fixture.resolver(t)
+	if _, err := resolver.Resolve(context.Background(), &xgoprojs.DirProj{Dir: filepath.Join(legacy, "...")}); !errors.Is(err, ErrNotHandled) {
+		t.Fatalf("legacy pattern = %v, want ErrNotHandled", err)
+	}
+	if _, err := resolver.Resolve(context.Background(), &xgoprojs.DirProj{Dir: filepath.Join(fixture.project, "...")}); err == nil || !strings.Contains(err.Error(), "directory pattern") {
+		t.Fatalf("driver pattern error = %v", err)
+	}
+	if _, err := resolver.Resolve(context.Background(), &xgoprojs.DirProj{Dir: filepath.Join(fixture.app, "...")}); err == nil || !strings.Contains(err.Error(), "directory pattern") {
+		t.Fatalf("parent pattern containing driver-backed project error = %v", err)
+	}
+	if _, err := resolver.Resolve(context.Background(), &xgoprojs.PkgPathProj{Path: "example.test/app/legacy/..."}); !errors.Is(err, ErrNotHandled) {
+		t.Fatalf("legacy package pattern = %v, want ErrNotHandled", err)
+	}
+	if _, err := resolver.Resolve(context.Background(), &xgoprojs.PkgPathProj{Path: "example.test/app/..."}); err == nil || !strings.Contains(err.Error(), "package pattern") {
+		t.Fatalf("package pattern containing driver-backed project error = %v", err)
+	}
+}
+
+func TestResolveDriverWithoutPack(t *testing.T) {
+	if testing.Short() {
+		t.Skip("invokes the host Go command")
+	}
+	fixture := newDriverFixture(t)
+	goxmod := filepath.Join(fixture.framework, "gox.mod")
+	data, err := os.ReadFile(goxmod)
+	if err != nil {
+		t.Fatal(err)
+	}
+	data = bytes.ReplaceAll(data, []byte("pack pack index.data\n"), nil)
+	if err := os.WriteFile(goxmod, data, 0644); err != nil {
+		t.Fatal(err)
+	}
+	drv := resolveDriver(t, fixture.resolver(t), &xgoprojs.DirProj{Dir: fixture.project})
+	if drv.PackDir != "" || drv.PackIndex != "" {
+		t.Fatalf("pack = %q, %q", drv.PackDir, drv.PackIndex)
+	}
+	args, err := driverArgs(drv, actionRun, BuildPolicy{}, "", "", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, arg := range args {
+		if strings.HasPrefix(arg, "--pack-") {
+			t.Fatalf("optional pack leaked into argv: %#v", args)
+		}
+	}
+}
+
+func TestResolveRejectsUnsupportedDriverProtocol(t *testing.T) {
+	if testing.Short() {
+		t.Skip("invokes the host Go command")
+	}
+	fixture := newDriverFixture(t)
+	goxmod := filepath.Join(fixture.framework, "gox.mod")
+	data, err := os.ReadFile(goxmod)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(goxmod, bytes.Replace(data, []byte("driver v1 "), []byte("driver v2 "), 1), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	_, err = fixture.resolver(t).Resolve(context.Background(), &xgoprojs.DirProj{Dir: fixture.project})
+	if err == nil || !strings.Contains(err.Error(), `unsupported driver protocol "v2"`) {
+		t.Fatalf("Resolve() = %v", err)
+	}
+}
+
+func TestDeclaringMetadataRejectsChangeAfterDiscovery(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "gox.mod")
+	original := []byte("xgo 1.8\n")
+	if err := os.WriteFile(path, original, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	snapshot := xgomod.FileIdentity{Path: path, SHA256: sha256Bytes(original)}
+	origin := ResolvedModule{Selected: ModuleRef{Path: "example.test/driver", Dir: dir, GoMod: filepath.Join(dir, "go.mod")}, Main: true}
+	if _, err := declaringMetadata(origin, snapshot); err != nil {
+		t.Fatalf("unchanged declaration rejected: %v", err)
+	}
+	if err := os.WriteFile(path, []byte("xgo 1.9\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := declaringMetadata(origin, snapshot); err == nil || !strings.Contains(err.Error(), "changed after discovery") {
+		t.Fatalf("changed declaration error = %v", err)
+	}
+}
+
+func TestResolveDriverRejectsAmbiguousAndMultiFile(t *testing.T) {
+	if testing.Short() {
+		t.Skip("invokes the host Go command")
+	}
+	fixture := newDriverFixture(t)
+	resolver := fixture.resolver(t)
+	other := filepath.Join(fixture.project, "other.foo")
+	mustWriteFile(t, other, "// another project\n")
+	_, err := resolver.Resolve(context.Background(), &xgoprojs.DirProj{Dir: fixture.project})
+	if err == nil || !strings.Contains(err.Error(), "2 project files") {
+		t.Fatalf("ambiguity error = %v", err)
+	}
+	if err := os.Remove(other); err != nil {
+		t.Fatal(err)
+	}
+	plain := filepath.Join(fixture.app, "plain.xgo")
+	mustWriteFile(t, plain, "// ordinary source\n")
+	_, err = resolver.Resolve(context.Background(), &xgoprojs.FilesProj{Files: []string{plain, fixture.mainFile}})
+	if err == nil || !strings.Contains(err.Error(), "multiple source-file") {
+		t.Fatalf("multi-file error = %v", err)
+	}
+}
+
+func TestResolveProjectFilesFailClosed(t *testing.T) {
+	if testing.Short() {
+		t.Skip("invokes the host Go command")
+	}
+	t.Run("direct symlink", func(t *testing.T) {
+		fixture := newDriverFixture(t)
+		plainDir := filepath.Join(fixture.app, "plain")
+		mustMkdirAll(t, plainDir)
+		real := filepath.Join(plainDir, "real.xgo")
+		mustWriteFile(t, real, "// ordinary source\n")
+		link := filepath.Join(fixture.project, "selected.foo")
+		if err := os.Symlink(real, link); err != nil {
+			t.Skipf("symlink unavailable: %v", err)
+		}
+		_, err := fixture.resolver(t).Resolve(context.Background(), &xgoprojs.FilesProj{Files: []string{link}})
+		if err == nil || errors.Is(err, ErrNotHandled) || !strings.Contains(err.Error(), "non-symlink") {
+			t.Fatalf("direct symlink error = %v", err)
+		}
+	})
+	t.Run("ordinary symlink remains legacy", func(t *testing.T) {
+		fixture := newDriverFixture(t)
+		plainDir := filepath.Join(fixture.app, "plain")
+		mustMkdirAll(t, plainDir)
+		link := filepath.Join(plainDir, "selected.xgo")
+		if err := os.Symlink(fixture.mainFile, link); err != nil {
+			t.Skipf("symlink unavailable: %v", err)
+		}
+		if _, err := fixture.resolver(t).Resolve(context.Background(), &xgoprojs.FilesProj{Files: []string{link}}); !errors.Is(err, ErrNotHandled) {
+			t.Fatalf("ordinary symlink error = %v, want ErrNotHandled", err)
+		}
+	})
+	t.Run("missing ordinary files remain legacy", func(t *testing.T) {
+		fixture := newDriverFixture(t)
+		plainDir := filepath.Join(fixture.app, "plain")
+		mustMkdirAll(t, plainDir)
+		dangling := filepath.Join(plainDir, "dangling.xgo")
+		if err := os.Symlink(filepath.Join(plainDir, "missing-target"), dangling); err != nil {
+			t.Skipf("symlink unavailable: %v", err)
+		}
+		for _, name := range []string{dangling, filepath.Join(plainDir, "missing.xgo")} {
+			if _, err := fixture.resolver(t).Resolve(context.Background(), &xgoprojs.FilesProj{Files: []string{name}}); !errors.Is(err, ErrNotHandled) {
+				t.Fatalf("ordinary missing target %q error = %v, want ErrNotHandled", name, err)
+			}
+		}
+	})
+	t.Run("ordinary symlink before driver remains multi-file error", func(t *testing.T) {
+		fixture := newDriverFixture(t)
+		plainDir := filepath.Join(fixture.app, "plain")
+		mustMkdirAll(t, plainDir)
+		real := filepath.Join(plainDir, "real.xgo")
+		link := filepath.Join(plainDir, "selected.xgo")
+		mustWriteFile(t, real, "// ordinary source\n")
+		if err := os.Symlink(real, link); err != nil {
+			t.Skipf("symlink unavailable: %v", err)
+		}
+		_, err := fixture.resolver(t).Resolve(context.Background(), &xgoprojs.FilesProj{Files: []string{link, fixture.mainFile}})
+		if err == nil || !strings.Contains(err.Error(), "multiple source-file") {
+			t.Fatalf("multi-file symlink error = %v", err)
+		}
+	})
+	t.Run("directory symlink", func(t *testing.T) {
+		fixture := newDriverFixture(t)
+		backing := filepath.Join(fixture.project, "project-source")
+		if err := os.Rename(fixture.mainFile, backing); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.Symlink(backing, fixture.mainFile); err != nil {
+			t.Skipf("symlink unavailable: %v", err)
+		}
+		_, err := fixture.resolver(t).Resolve(context.Background(), &xgoprojs.DirProj{Dir: fixture.project})
+		if err == nil || errors.Is(err, ErrNotHandled) || !strings.Contains(err.Error(), "driver project file") {
+			t.Fatalf("directory symlink error = %v", err)
+		}
+	})
+	t.Run("pattern symlink", func(t *testing.T) {
+		fixture := newDriverFixture(t)
+		backing := filepath.Join(fixture.project, "project-source")
+		if err := os.Rename(fixture.mainFile, backing); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.Symlink(backing, fixture.mainFile); err != nil {
+			t.Skipf("symlink unavailable: %v", err)
+		}
+		_, err := fixture.resolver(t).Resolve(context.Background(), &xgoprojs.DirProj{Dir: filepath.Join(fixture.app, "...")})
+		if err == nil || errors.Is(err, ErrNotHandled) || !strings.Contains(err.Error(), "driver project file") {
+			t.Fatalf("pattern symlink error = %v", err)
+		}
+	})
+	t.Run("special file", func(t *testing.T) {
+		fixture := newDriverFixture(t)
+		if err := os.Remove(fixture.mainFile); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.Mkdir(fixture.mainFile, 0o755); err != nil {
+			t.Fatal(err)
+		}
+		_, err := fixture.resolver(t).Resolve(context.Background(), &xgoprojs.DirProj{Dir: fixture.project})
+		if err == nil || errors.Is(err, ErrNotHandled) || !strings.Contains(err.Error(), "regular non-symlink") {
+			t.Fatalf("special project file error = %v", err)
+		}
+	})
+	t.Run("vanished direct file", func(t *testing.T) {
+		fixture := newDriverFixture(t)
+		vanished := filepath.Join(fixture.project, "vanished.foo")
+		mustWriteFile(t, vanished, "// selected then removed\n")
+		if err := os.Remove(vanished); err != nil {
+			t.Fatal(err)
+		}
+		_, err := fixture.resolver(t).Resolve(context.Background(), &xgoprojs.FilesProj{Files: []string{vanished}})
+		if err == nil || errors.Is(err, ErrNotHandled) {
+			t.Fatalf("vanished file error = %v", err)
+		}
+	})
+}
+
+func TestResolveNonDriverNotHandled(t *testing.T) {
+	if testing.Short() {
+		t.Skip("invokes the host Go command")
+	}
+	dir := t.TempDir()
+	mustWriteFile(t, filepath.Join(dir, "go.mod"), "module example.test/plain\n\ngo 1.25\n")
+	mustWriteFile(t, filepath.Join(dir, "main.go"), "package main\nfunc main() {}\n")
+	resolver, err := NewResolver(context.Background(), dir, []string{"-tags=legacy-only"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, err = resolver.Resolve(context.Background(), &xgoprojs.DirProj{Dir: dir})
+	if !errors.Is(err, ErrNotHandled) {
+		t.Fatalf("plain project = %v", err)
+	}
+}
+
+func TestResolverRejectsAmbientPolicyFailureWithoutFallback(t *testing.T) {
+	if testing.Short() {
+		t.Skip("invokes the host Go command")
+	}
+	dir := t.TempDir()
+	mustWriteFile(t, filepath.Join(dir, "go.mod"), "module example.test/plain\n\ngo 1.25\n")
+	mustWriteFile(t, filepath.Join(dir, "main.go"), "package main\nfunc main() {}\n")
+	t.Setenv("GOWORK", "off")
+	t.Setenv("GOFLAGS", "'unterminated")
+	if resolver, err := NewResolver(context.Background(), dir, nil); err == nil || resolver != nil {
+		t.Fatalf("NewResolver() = %#v, %v; want policy error without fallback graph", resolver, err)
+	}
+}
+
+func TestResolverDefersMissingGraphFileForLegacy(t *testing.T) {
+	if testing.Short() {
+		t.Skip("invokes the host Go command")
+	}
+	dir := t.TempDir()
+	mustWriteFile(t, filepath.Join(dir, "go.mod"), "module example.test/plain\n\ngo 1.25\n")
+	mustWriteFile(t, filepath.Join(dir, "main.go"), "package main\nfunc main() {}\n")
+	t.Setenv("GOWORK", "off")
+	resolver, err := NewResolver(context.Background(), dir, []string{"-modfile=missing.mod"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := resolver.Resolve(context.Background(), &xgoprojs.DirProj{Dir: dir}); !errors.Is(err, ErrNotHandled) {
+		t.Fatalf("legacy target = %v", err)
+	}
+}
+
+func TestResolverDefersInvalidBuildBooleanForLegacy(t *testing.T) {
+	if testing.Short() {
+		t.Skip("invokes the host Go command")
+	}
+	dir := t.TempDir()
+	mustWriteFile(t, filepath.Join(dir, "go.mod"), "module example.test/plain\n\ngo 1.25\n")
+	mustWriteFile(t, filepath.Join(dir, "main.go"), "package main\nfunc main() {}\n")
+	t.Setenv("GOWORK", "off")
+	for _, flag := range []string{"-v=invalid", "-x=invalid", "-work=invalid"} {
+		for _, source := range []string{"cli", "ambient"} {
+			t.Run(strings.TrimPrefix(flag, "-")+"/"+source, func(t *testing.T) {
+				var cli []string
+				if source == "ambient" {
+					t.Setenv("GOFLAGS", flag)
+				} else {
+					t.Setenv("GOFLAGS", "")
+					cli = []string{flag}
+				}
+				resolver, err := NewResolver(context.Background(), dir, cli)
+				if err != nil {
+					t.Fatal(err)
+				}
+				if _, err := resolver.Resolve(context.Background(), &xgoprojs.DirProj{Dir: dir}); !errors.Is(err, ErrNotHandled) {
+					t.Fatalf("legacy target = %v, want ErrNotHandled", err)
+				}
+			})
+		}
+	}
+}
+
+func TestResolverRejectsInvalidBuildBooleanAtDriverMatch(t *testing.T) {
+	if testing.Short() {
+		t.Skip("invokes the host Go command")
+	}
+	fixture := newDriverFixture(t)
+	for _, flag := range []string{"-v=invalid", "-x=invalid", "-work=invalid"} {
+		t.Run(strings.TrimPrefix(flag, "-"), func(t *testing.T) {
+			resolver := fixture.resolver(t, flag)
+			driver, err := resolver.Resolve(context.Background(), &xgoprojs.DirProj{Dir: fixture.project})
+			if err == nil || driver != nil || !strings.Contains(err.Error(), flag) {
+				t.Fatalf("Resolve() = %#v, %v; want rejection of %q", driver, err, flag)
+			}
+		})
+	}
+}
+
+func TestCheckRequiredXGo(t *testing.T) {
+	tests := []struct {
+		required string
+		current  string
+		ok       bool
+	}{
+		{"1.8", "v1.8.0", true},
+		{"v1.8.1", "v1.9.0", true},
+		{"1.8", "v1.7.5", false},
+		{"1.9", "v1.8.9", false},
+		{"1.8", "(devel)", true},
+		{"1.8.1", "(devel)", false},
+		{"1.8", "v1.7.5 devel", true},
+		{"1.8.1", "v1.7.5 devel", false},
+		{"1.8", "xgo v1.9.0-devel", true},
+		{"1.8", "v1.2.0-pre.1.0.20260821130422-831eec0b6b4e", true},
+		{"1.8.1", "v1.2.0-pre.1.0.20260821130422-831eec0b6b4e", false},
+		{"", "(devel)", true},
+	}
+	for _, test := range tests {
+		err := checkRequiredXGo(test.required, test.current)
+		if (err == nil) != test.ok {
+			t.Fatalf("checkRequiredXGo(%q, %q) = %v", test.required, test.current, err)
+		}
+	}
+}
+
+func TestCheckDriverXGoVersion(t *testing.T) {
+	tests := []struct {
+		declared string
+		current  string
+		ok       bool
+	}{
+		{"", "v1.8.0", true},
+		{"1.0", "v1.7.9", false},
+		{"1.0", "v1.8.0", true},
+		{"1.9", "v1.8.9", false},
+		{"1.9", "v1.9.0", true},
+		{"1.0", "(devel)", true},
+		{"1.9", "(devel)", false},
+	}
+	for _, test := range tests {
+		if err := checkDriverXGoVersion(test.declared, test.current); (err == nil) != test.ok {
+			t.Fatalf("checkDriverXGoVersion(%q, %q) = %v", test.declared, test.current, err)
+		}
+	}
+}
+
+func TestCheckRequiredXGoReportsPseudoDevelopmentCapability(t *testing.T) {
+	version := "v1.2.0-pre.1.0.20260821130422-831eec0b6b4e"
+	err := checkRequiredXGo("1.8.1", version)
+	if err == nil {
+		t.Fatal("pseudo-version development build unexpectedly satisfied a newer capability")
+	}
+	for _, want := range []string{version, "driver capability 1.8.0"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Fatalf("checkRequiredXGo() error = %q, want %q", err, want)
+		}
+	}
+}
+
+func TestCheckRequiredXGoReportsDevelopmentCapability(t *testing.T) {
+	err := checkRequiredXGo("1.8.1", "(devel)")
+	if err == nil {
+		t.Fatal("development build unexpectedly satisfied a newer capability")
+	}
+	for _, want := range []string{"declaring module requires XGo 1.8.1", "(devel)", "driver capability 1.8.0"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Fatalf("checkRequiredXGo() error = %q, want %q", err, want)
+		}
+	}
+}
+
+func TestResolveUsesDeclaringModuleXGoRequirement(t *testing.T) {
+	if testing.Short() {
+		t.Skip("invokes the host Go command")
+	}
+	fixture := newDriverFixture(t)
+	resolver := fixture.resolver(t)
+	resolver.xgoVersion = "v1.8.0"
+	resolveDriver(t, resolver, &xgoprojs.DirProj{Dir: fixture.project})
+
+	setFixtureRequiredXGo(t, fixture, "1.9.0")
+	resolver = fixture.resolver(t)
+	resolver.xgoVersion = "v1.8.9"
+	_, err := resolver.Resolve(context.Background(), &xgoprojs.DirProj{Dir: fixture.project})
+	if err == nil || !strings.Contains(err.Error(), "declaring module requires XGo 1.9.0") {
+		t.Fatalf("Resolve() = %v, want declaring-module version error", err)
+	}
+
+	resolver = fixture.resolver(t)
+	resolver.xgoVersion = "v1.9.0"
+	resolveDriver(t, resolver, &xgoprojs.DirProj{Dir: fixture.project})
+}

--- a/cmd/internal/projectdriver/resolve_project.go
+++ b/cmd/internal/projectdriver/resolve_project.go
@@ -1,0 +1,259 @@
+/*
+ * Copyright (c) 2026 The XGo Authors (xgo.dev). All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package projectdriver
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+
+	"github.com/goplus/mod/modfile"
+	"github.com/goplus/mod/modload"
+	"github.com/goplus/mod/xgomod"
+)
+
+const driverGuardEnv = "XGO_DRIVER_GUARD"
+
+// loadDriverModule preserves metadata fallback and reports unreadable optional files.
+func loadDriverModule(goMod, goxMod string) (modload.Module, error) {
+	return loadDriverModuleView(goMod, goxMod, nil)
+}
+
+func loadDriverModuleView(goMod, goxMod string, view *graphFileView) (modload.Module, error) {
+	optionalPaths := map[string]struct{}{goxMod: {}}
+	if strings.HasSuffix(goxMod, "gox.mod") {
+		optionalPaths[strings.TrimSuffix(goxMod, "gox.mod")+"gop.mod"] = struct{}{}
+	}
+	var optionalErr error
+	loaded, err := modload.LoadFromEx(goMod, goxMod, func(path string) ([]byte, error) {
+		data, readErr := view.readFile(path)
+		if _, optional := optionalPaths[path]; optional && readErr != nil && !os.IsNotExist(readErr) && optionalErr == nil {
+			optionalErr = fmt.Errorf("read optional module metadata %q: %w", path, readErr)
+		}
+		return data, readErr
+	})
+	if optionalErr != nil {
+		return modload.Module{}, optionalErr
+	}
+	return loaded, err
+}
+
+func externalClassModule(module modload.Module) string {
+	for _, require := range module.Require {
+		if require.Syntax != nil && modload.HasClassMarker(require.Syntax.Suffix) {
+			return require.Mod.Path
+		}
+	}
+	return ""
+}
+
+func driverProjectMatches(projects []*modfile.Project, name string) bool {
+	ext := modfile.ClassExt(name)
+	for _, project := range projects {
+		if project != nil && project.Driver != nil && project.Ext == ext && project.IsProj(ext, name) {
+			return true
+		}
+	}
+	return false
+}
+
+func loadResolvedClasses(graph *effectiveGraph) (*xgomod.Module, bool, error) {
+	target := graph.Target.Effective()
+	loaded, err := loadDriverModuleView(graph.TargetModFile.Path, filepath.Join(target.Dir, "gox.mod"), graph.files)
+	if err != nil {
+		return nil, false, err
+	}
+	hasClass := len(graph.ClassModules) != 0 || loaded.HasProject()
+	if !hasClass {
+		return nil, false, nil
+	}
+	module := xgomod.New(loaded)
+	if err := module.ImportClassesResolved(toXGoGraph(graph)); err != nil {
+		return nil, false, err
+	}
+	return module, true, nil
+}
+
+func toXGoGraph(graph *effectiveGraph) xgomod.ResolvedClassGraph {
+	// xgomod needs only the target and marked modules; the full graph remains
+	// available for package resolution.
+	return xgomod.ResolvedClassGraph{
+		Target: graph.Target, ClassModules: graph.ClassModules, TargetModFile: graph.TargetModFile,
+	}
+}
+
+func findProjectFile(dir string, module *xgomod.Module) (string, *xgomod.ProjectInfo, int, error) {
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return "", nil, 0, err
+	}
+	var (
+		projectFile string
+		projectInfo *xgomod.ProjectInfo
+		count       int
+	)
+	for _, entry := range entries {
+		ext := modfile.ClassExt(entry.Name())
+		classInfo, ok := module.LookupClassInfo(ext)
+		if !ok || !classInfo.Project.IsProj(ext, entry.Name()) {
+			continue
+		}
+		driverProject := classInfo.Project.Driver != nil
+		info, err := entry.Info()
+		if err != nil {
+			return "", nil, 0, err
+		}
+		if !info.Mode().IsRegular() {
+			if driverProject {
+				return "", nil, 0, fmt.Errorf("driver project file %q is not a regular non-symlink file", filepath.Join(dir, entry.Name()))
+			}
+			continue
+		}
+		count++
+		if driverProject {
+			projectFile = filepath.Join(dir, entry.Name())
+			projectInfo = classInfo
+		}
+	}
+	return projectFile, projectInfo, count, nil
+}
+
+var errDriverProjectInPattern = errors.New("driver-backed project in pattern")
+
+func patternContainsDriverProject(root string, module *xgomod.Module) (bool, error) {
+	return walkDriverPattern(root, func(dir string) (bool, error) {
+		_, info, _, err := findProjectFile(dir, module)
+		return info != nil, err
+	})
+}
+
+func patternContainsDriverProjects(root string, projects []*modfile.Project) (bool, error) {
+	return walkDriverPattern(root, func(dir string) (bool, error) {
+		return hasDriverProject(dir, projects)
+	})
+}
+
+func walkDriverPattern(root string, matches func(string) (bool, error)) (bool, error) {
+	err := filepath.WalkDir(root, func(current string, entry os.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			return walkErr
+		}
+		if !entry.IsDir() {
+			return nil
+		}
+		if current != root {
+			name := entry.Name()
+			if name == "vendor" || name == "testdata" || strings.HasPrefix(name, ".") || strings.HasPrefix(name, "_") {
+				return filepath.SkipDir
+			}
+			goMod := filepath.Join(current, "go.mod")
+			if info, err := os.Lstat(goMod); err == nil {
+				if info.Mode()&os.ModeSymlink != 0 || !info.Mode().IsRegular() {
+					return fmt.Errorf("nested module marker %q is not a regular non-symlink file", goMod)
+				}
+				return filepath.SkipDir
+			} else if !os.IsNotExist(err) {
+				return err
+			}
+		}
+		matched, err := matches(current)
+		if err != nil {
+			return err
+		}
+		if matched {
+			return errDriverProjectInPattern
+		}
+		return nil
+	})
+	if errors.Is(err, errDriverProjectInPattern) {
+		return true, nil
+	}
+	return false, err
+}
+
+func validatePack(projectDir string, pack *modfile.Pack) (string, string, error) {
+	if pack == nil {
+		return "", "", nil
+	}
+	dir := filepath.Clean(filepath.FromSlash(pack.Directory))
+	if pack.Directory == "" || filepath.IsAbs(dir) || dir == ".." || strings.HasPrefix(dir, ".."+string(filepath.Separator)) {
+		return "", "", fmt.Errorf("driver pack directory %q is invalid", pack.Directory)
+	}
+	if pack.IndexFile == "" || filepath.Base(pack.IndexFile) != pack.IndexFile || strings.ContainsAny(pack.IndexFile, `/\`) {
+		return "", "", fmt.Errorf("driver pack index %q is invalid", pack.IndexFile)
+	}
+	root := filepath.Join(projectDir, dir)
+	canonical, err := canonicalExistingDir(root)
+	if err != nil {
+		return "", "", fmt.Errorf("driver pack directory: %w", err)
+	}
+	if !pathWithin(projectDir, canonical) {
+		return "", "", fmt.Errorf("driver pack directory escapes the project")
+	}
+	return filepath.ToSlash(dir), pack.IndexFile, nil
+}
+
+func sameFile(a, b string) (bool, error) {
+	aInfo, err := os.Stat(a)
+	if err != nil {
+		return false, err
+	}
+	bInfo, err := os.Stat(b)
+	if err != nil {
+		return false, err
+	}
+	return os.SameFile(aInfo, bInfo), nil
+}
+
+func defaultExecutableName(projectDir, importPath string) string {
+	if importPath == "" {
+		return filepath.Base(projectDir)
+	}
+	parts := strings.Split(strings.TrimSuffix(importPath, "/"), "/")
+	name := parts[len(parts)-1]
+	if majorVersionRE.MatchString(name) && len(parts) > 1 {
+		name = parts[len(parts)-2]
+	}
+	return name
+}
+
+var majorVersionRE = regexp.MustCompile(`^v(?:[2-9]|[1-9][0-9]+)$`)
+
+func hasRecursivePattern(target string) bool {
+	clean := filepath.ToSlash(filepath.Clean(target))
+	return clean == "..." || strings.HasSuffix(clean, "/...")
+}
+
+func trimRecursivePattern(target string) string {
+	clean := filepath.ToSlash(filepath.Clean(target))
+	clean = strings.TrimSuffix(clean, "...")
+	clean = strings.TrimSuffix(clean, "/")
+	if clean == "" {
+		return "."
+	}
+	return filepath.FromSlash(clean)
+}
+
+func sha256Bytes(data []byte) string {
+	sum := sha256.Sum256(data)
+	return hex.EncodeToString(sum[:])
+}

--- a/cmd/internal/projectdriver/resolve_target.go
+++ b/cmd/internal/projectdriver/resolve_target.go
@@ -1,0 +1,120 @@
+/*
+ * Copyright (c) 2026 The XGo Authors (xgo.dev). All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package projectdriver
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/goplus/xgo/x/xgoprojs"
+)
+
+type targetResolution struct {
+	original         string
+	projectDir       string
+	targetImportPath string
+	expectedFile     string
+	expectedFileInfo os.FileInfo
+	fileError        error
+	multiFile        bool
+	unsupportedForm  string
+	recursive        bool
+	graph            *effectiveGraph
+	graphWorkDir     string
+}
+
+func (r *Resolver) classifyTarget(ctx context.Context, target xgoprojs.Proj) (targetResolution, error) {
+	switch target := target.(type) {
+	case *xgoprojs.DirProj:
+		return r.classifyDirectoryTarget(ctx, target)
+	case *xgoprojs.FilesProj:
+		if len(target.Files) == 0 {
+			return targetResolution{}, ErrNotHandled
+		}
+		return r.classifyFileTarget(target.Files[0])
+	case *xgoprojs.PkgPathProj:
+		return r.classifyPackageTarget(ctx, target)
+	default:
+		return targetResolution{}, ErrNotHandled
+	}
+}
+
+func (r *Resolver) classifyDirectoryTarget(ctx context.Context, target *xgoprojs.DirProj) (targetResolution, error) {
+	result := targetResolution{graphWorkDir: r.cwd}
+	candidate := target.Dir
+	if hasRecursivePattern(candidate) {
+		result.unsupportedForm = "directory pattern containing ..."
+		result.recursive = true
+		candidate = trimRecursivePattern(candidate)
+	}
+	if !filepath.IsAbs(candidate) {
+		candidate = filepath.Join(r.cwd, candidate)
+	}
+	projectDir, err := canonicalExistingDir(candidate)
+	if err == nil {
+		result.projectDir = projectDir
+		result.graphWorkDir = projectDir
+		return result, nil
+	}
+	if isMissingPathError(err) && r.policy.graph.Overlay != "" {
+		result.projectDir, result.graph, err = r.resolveOverlayLocalTarget(ctx, candidate, result.recursive)
+		if err != nil {
+			return targetResolution{}, err
+		}
+		return result, nil
+	}
+	if isMissingPathError(err) {
+		return targetResolution{}, ErrNotHandled
+	}
+	return targetResolution{}, err
+}
+
+func (r *Resolver) classifyFileTarget(name string) (targetResolution, error) {
+	absolute := name
+	if !filepath.IsAbs(absolute) {
+		absolute = filepath.Join(r.cwd, absolute)
+	}
+	projectDir, err := canonicalExistingDir(filepath.Dir(filepath.Clean(absolute)))
+	if err != nil {
+		return targetResolution{}, err
+	}
+	file := filepath.Join(projectDir, filepath.Base(absolute))
+	fileInfo, inspectErr := os.Lstat(file)
+	var fileErr error
+	if inspectErr != nil {
+		fileErr = fmt.Errorf("project file %q cannot be inspected: %w", name, inspectErr)
+		fileInfo = nil
+	} else if fileInfo.Mode()&os.ModeSymlink != 0 || !fileInfo.Mode().IsRegular() {
+		fileErr = fmt.Errorf("project file %q is not a regular non-symlink file", name)
+		fileInfo = nil
+	}
+	return targetResolution{
+		original:         name,
+		projectDir:       projectDir,
+		expectedFile:     file,
+		expectedFileInfo: fileInfo,
+		fileError:        fileErr,
+		graphWorkDir:     projectDir,
+	}, nil
+}
+
+func isMissingPathError(err error) bool {
+	return os.IsNotExist(err) || os.IsNotExist(errors.Unwrap(err))
+}

--- a/cmd/internal/projectdriver/resolve_test.go
+++ b/cmd/internal/projectdriver/resolve_test.go
@@ -1,0 +1,173 @@
+/*
+ * Copyright (c) 2026 The XGo Authors (xgo.dev). All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package projectdriver
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/goplus/xgo/x/xgoprojs"
+)
+
+func TestLoadResolvedClassesWithoutClassMetadata(t *testing.T) {
+	root := t.TempDir()
+	goMod := filepath.Join(root, "go.mod")
+	mustModuleFile(t, goMod, "example.test/plain")
+	target := ResolvedModule{
+		Selected: ModuleRef{Path: "example.test/plain", Dir: root, GoMod: goMod},
+		Main:     true,
+	}
+	module, hasClass, err := loadResolvedClasses(&effectiveGraph{
+		Target:        target,
+		TargetModFile: fileIdentity{Path: goMod},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if hasClass || module != nil {
+		t.Fatalf("loadResolvedClasses() = %#v, %t; want nil, false", module, hasClass)
+	}
+}
+
+func TestDefaultExecutableNameSemanticImportVersion(t *testing.T) {
+	for path, want := range map[string]string{
+		"example.test/tool/v1":  "v1",
+		"example.test/tool/v10": "tool",
+		"example.test/tool/v19": "tool",
+		"example.test/tool/v02": "v02",
+	} {
+		t.Run(path, func(t *testing.T) {
+			if got := defaultExecutableName(t.TempDir(), path); got != want {
+				t.Fatalf("defaultExecutableName() = %q, want %q", got, want)
+			}
+		})
+	}
+}
+
+func TestResolverCWDAnchorsRelativeTargets(t *testing.T) {
+	root := t.TempDir()
+	project := filepath.Join(root, "project")
+	file := filepath.Join(project, "main.foo")
+	mustMkdirAll(t, project)
+	mustWriteFile(t, file, "project\n")
+	project = canonicalDir(t, project)
+	file = canonicalFile(t, file)
+	resolver := &Resolver{cwd: root}
+
+	directory, err := resolver.classifyDirectoryTarget(context.Background(), &xgoprojs.DirProj{Dir: "project"})
+	if err != nil || directory.projectDir != project {
+		t.Fatalf("relative directory = %q, %v", directory.projectDir, err)
+	}
+	files, err := resolver.classifyFileTarget(filepath.Join("project", "main.foo"))
+	if err != nil || files.expectedFile != file {
+		t.Fatalf("relative file = %q, %v", files.expectedFile, err)
+	}
+}
+
+func TestResolveDriverTargets(t *testing.T) {
+	if testing.Short() {
+		t.Skip("invokes the host Go command")
+	}
+	fixture := newDriverFixture(t)
+	goMod := canonicalFile(t, filepath.Join(fixture.app, "go.mod"))
+	goModData, err := os.ReadFile(goMod)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for name, target := range map[string]xgoprojs.Proj{
+		"directory": &xgoprojs.DirProj{Dir: fixture.project},
+		"file":      &xgoprojs.FilesProj{Files: []string{fixture.mainFile}},
+		"package":   &xgoprojs.PkgPathProj{Path: "example.test/app/game"},
+	} {
+		t.Run(name, func(t *testing.T) {
+			drv := resolveDriver(t, fixture.resolver(t), target)
+			if drv.ProjectDir != canonicalDir(t, fixture.project) || drv.ProjectFile != canonicalFile(t, fixture.mainFile) {
+				t.Fatalf("project identity = %q, %q", drv.ProjectDir, drv.ProjectFile)
+			}
+			if drv.DriverPackage != "example.test/framework/cmd/driver" {
+				t.Fatalf("driver = %#v", drv)
+			}
+			if drv.Origin.Selected.Path != "example.test/framework" || drv.Origin.Selected.Version != "v1.2.3" || drv.Origin.Replace == nil {
+				t.Fatalf("origin = %#v", drv.Origin)
+			}
+			if drv.Origin.Selected.Dir != "" || drv.Origin.Replace.Path != canonicalDir(t, fixture.framework) {
+				t.Fatalf("replacement identity was flattened: %#v", drv.Origin)
+			}
+			if drv.PackDir != "pack" || drv.PackIndex != "index.data" || len(drv.Declaration.SHA256) != 64 {
+				t.Fatalf("metadata = %#v", drv)
+			}
+			if drv.TargetModFile.Path != goMod || drv.TargetModFile.SHA256 != sha256Bytes(goModData) {
+				t.Fatalf("target modfile = %#v", drv.TargetModFile)
+			}
+		})
+	}
+}
+
+func TestResolveRejectsAnyNestedDriverDispatch(t *testing.T) {
+	if testing.Short() {
+		t.Skip("invokes the host Go command")
+	}
+	fixture := newDriverFixture(t)
+	resolver := fixture.resolver(t)
+	target := &xgoprojs.DirProj{Dir: fixture.project}
+	t.Setenv(driverGuardEnv, "1")
+	if _, err := resolver.Resolve(context.Background(), target); !errors.Is(err, ErrDriverRecursive) {
+		t.Fatalf("Resolve() = %v, want ErrDriverRecursive", err)
+	}
+}
+
+func TestResolvePackageTargetKeepsCallerGraph(t *testing.T) {
+	if testing.Short() {
+		t.Skip("invokes the host Go command")
+	}
+	fixture := newDriverFixture(t)
+	dependencyProject := filepath.Join(fixture.framework, "example")
+	mustMkdirAll(t, filepath.Join(dependencyProject, "pack"))
+	mustWriteFile(t, filepath.Join(dependencyProject, "main.foo"), "// dependency project\n")
+	mustWriteFile(t, filepath.Join(dependencyProject, "pack", "index.data"), "{}\n")
+
+	resolver := fixture.resolver(t)
+	drv := resolveDriver(t, resolver, &xgoprojs.PkgPathProj{Path: "example.test/framework/example"})
+	if drv.ModuleRoot != canonicalDir(t, fixture.framework) || drv.Graph.WorkDir != canonicalDir(t, fixture.app) {
+		t.Fatalf("graph roots = module %q, work %q", drv.ModuleRoot, drv.Graph.WorkDir)
+	}
+	if drv.Origin.Main || drv.Origin.Replace == nil || drv.Origin.Selected.Version != "v1.2.3" {
+		t.Fatalf("caller replacement graph was lost: %#v", drv.Origin)
+	}
+	if err := validateDriver(context.Background(), drv); err != nil {
+		t.Fatalf("driver validation switched graphs: %v", err)
+	}
+}
+
+func TestResolveXGoOnlyPackageTargetWithModfile(t *testing.T) {
+	if testing.Short() {
+		t.Skip("invokes the host Go command")
+	}
+	fixture := newDriverFixture(t)
+	data, err := os.ReadFile(filepath.Join(fixture.app, "go.mod"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	mustWriteFile(t, filepath.Join(fixture.app, "driver.mod"), string(data))
+	resolver := fixture.resolver(t, "-modfile=driver.mod")
+	if _, err := resolver.Resolve(context.Background(), &xgoprojs.PkgPathProj{Path: "example.test/app/game"}); err != nil {
+		t.Fatal(err)
+	}
+}

--- a/cmd/internal/projectdriver/resolve_vendor.go
+++ b/cmd/internal/projectdriver/resolve_vendor.go
@@ -1,0 +1,263 @@
+/*
+ * Copyright (c) 2026 The XGo Authors (xgo.dev). All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package projectdriver
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/goplus/mod/modfile"
+	"github.com/goplus/mod/modload"
+	gomodfile "golang.org/x/mod/modfile"
+)
+
+// preflightClassMetadata reads target metadata without loading the graph.
+// This keeps legacy vendor targets on the existing path.
+func (r *Resolver) preflightClassMetadata(ctx context.Context, dir string) (loaded modload.Module, moduleGoMod string, hasClass, vendor bool, err error) {
+	goMod, err := goModForDir(ctx, r.policy.graph, dir)
+	if err != nil {
+		return loaded, "", false, false, err
+	}
+	if goMod == "" || goMod == os.DevNull {
+		return loaded, "", false, false, errNoGoModule
+	}
+	moduleGoMod, err = canonicalExistingFile(goMod)
+	if err != nil {
+		return loaded, "", false, false, err
+	}
+	effectiveMod := moduleGoMod
+	if r.policy.graph.ModFile != "" {
+		effectiveMod = r.policy.graph.ModFile
+	}
+	identity, classMods, err := readTargetModFile(effectiveMod)
+	if err != nil {
+		return loaded, moduleGoMod, false, false, err
+	}
+	loaded, err = loadDriverModule(identity.Path, filepath.Join(filepath.Dir(moduleGoMod), "gox.mod"))
+	if err != nil {
+		return loaded, moduleGoMod, false, false, err
+	}
+	hasClass = len(classMods) != 0 || loaded.HasProject()
+	vendor, err = effectiveVendorMode(r.policy.graph, moduleGoMod, loaded.File)
+	return loaded, moduleGoMod, hasClass, vendor, err
+}
+
+// probeVendorPackage uses package-specific go list, which works in vendor mode.
+// Only main/workspace metadata is authoritative.
+func (r *Resolver) probeVendorPackage(ctx context.Context, moduleGoMod string, target modload.Module, importPath string, recursive bool) (bool, error) {
+	if classPath := externalClassModule(target); classPath != "" {
+		return false, r.vendorClassMetadataError(classPath)
+	}
+	pkg, err := listPackageTarget(ctx, importPath, r.cwd, r.policy.graph)
+	if err != nil {
+		return false, err
+	}
+	if pkg.ImportPath != importPath {
+		return false, fmt.Errorf("package target %q resolved as %q", importPath, pkg.ImportPath)
+	}
+	if pkg.Dir == "" || pkg.Module == nil {
+		if moduleContainsPackage(target.Path(), importPath) {
+			return r.probeVendorPackageInModule(ctx, moduleGoMod, target, importPath, recursive)
+		}
+		if r.policy.graph.GoWork != "off" {
+			return r.probeVendorWorkspacePackage(ctx, importPath, recursive)
+		}
+		return false, nil
+	}
+	if !pkg.Module.Main {
+		// An unmarked dependency cannot expand the driver trust boundary.
+		return false, nil
+	}
+	module, err := normalizeListedModule(*pkg.Module)
+	if err != nil {
+		return false, fmt.Errorf("package target %q: %w", importPath, err)
+	}
+	root := module.Effective().Dir
+	projectDir, err := canonicalExistingDir(pkg.Dir)
+	if err != nil {
+		return false, fmt.Errorf("package target %q: %w", importPath, err)
+	}
+	if !pathWithin(root, projectDir) {
+		return false, fmt.Errorf("package target %q escapes module %q", importPath, module.Selected.Path)
+	}
+	loaded, err := loadDriverModule(module.Effective().GoMod, filepath.Join(root, "gox.mod"))
+	if err != nil {
+		return false, err
+	}
+	return r.matchVendorModule(projectDir, loaded, recursive)
+}
+
+func (r *Resolver) probeVendorPackageInModule(ctx context.Context, moduleGoMod string, target modload.Module, importPath string, recursive bool) (bool, error) {
+	root := filepath.Dir(moduleGoMod)
+	suffix := strings.TrimPrefix(importPath, target.Path())
+	dir := filepath.Join(root, filepath.FromSlash(strings.TrimPrefix(suffix, "/")))
+	projectDir, err := canonicalExistingDir(dir)
+	if os.IsNotExist(err) {
+		return false, nil
+	}
+	if err != nil {
+		return false, err
+	}
+	if !pathWithin(root, projectDir) {
+		return false, nil
+	}
+	same, err := moduleOwnsPackage(ctx, r.policy.graph, moduleGoMod, projectDir)
+	if err != nil {
+		return false, err
+	}
+	if !same {
+		return false, nil
+	}
+	return matchVendorProjects(projectDir, target.Projects(), recursive)
+}
+
+func (r *Resolver) vendorClassMetadataError(modulePath string) error {
+	return fmt.Errorf("%w: class module %q metadata is not represented by standard Go vendor data", vendorUnsupportedError(string(r.policy.graph.ModMode)), modulePath)
+}
+
+func (r *Resolver) matchVendorModule(projectDir string, module modload.Module, recursive bool) (bool, error) {
+	if classPath := externalClassModule(module); classPath != "" {
+		return false, r.vendorClassMetadataError(classPath)
+	}
+	return matchVendorProjects(projectDir, module.Projects(), recursive)
+}
+
+func matchVendorProjects(dir string, projects []*modfile.Project, recursive bool) (bool, error) {
+	if recursive {
+		return patternContainsDriverProjects(dir, projects)
+	}
+	return hasDriverProject(dir, projects)
+}
+
+func hasDriverProject(dir string, projects []*modfile.Project) (bool, error) {
+	if len(projects) == 0 {
+		return false, nil
+	}
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return false, err
+	}
+	for _, entry := range entries {
+		if !driverProjectMatches(projects, entry.Name()) {
+			continue
+		}
+		info, err := entry.Info()
+		if err != nil {
+			return false, err
+		}
+		if !info.Mode().IsRegular() {
+			return false, fmt.Errorf("driver project file %q is not a regular non-symlink file", filepath.Join(dir, entry.Name()))
+		}
+		return true, nil
+	}
+	return false, nil
+}
+
+func effectiveVendorMode(policy GraphPolicy, moduleGoMod string, parsed *gomodfile.File) (bool, error) {
+	if policy.ModMode != "" {
+		return policy.ModMode == modModeVendor, nil
+	}
+	workspace := policy.GoWork != "" && policy.GoWork != "off"
+	var goVersion, vendorDir string
+	if workspace {
+		data, err := os.ReadFile(policy.GoWork)
+		if err != nil {
+			return false, err
+		}
+		work, err := gomodfile.ParseWork(policy.GoWork, data, nil)
+		if err != nil {
+			return false, err
+		}
+		if work.Go != nil {
+			goVersion = work.Go.Version
+		}
+		vendorDir = filepath.Join(filepath.Dir(policy.GoWork), "vendor")
+	} else {
+		if parsed.Go != nil {
+			goVersion = parsed.Go.Version
+		}
+		vendorDir = filepath.Join(filepath.Dir(moduleGoMod), "vendor")
+	}
+	if goVersion == "" || !versionAtLeast(goVersion, 1, 14) {
+		return false, nil
+	}
+	info, err := os.Stat(vendorDir)
+	if os.IsNotExist(err) {
+		return false, nil
+	}
+	if err != nil {
+		return false, err
+	}
+	if !info.IsDir() {
+		return false, nil
+	}
+	vendoredWorkspace, err := vendorManifestIsForWorkspace(vendorDir)
+	if err != nil {
+		return false, err
+	}
+	return vendoredWorkspace == workspace, nil
+}
+
+// A missing modules.txt denotes module vendor mode.
+func vendorManifestIsForWorkspace(vendorDir string) (bool, error) {
+	file, err := os.Open(filepath.Join(vendorDir, "modules.txt"))
+	if os.IsNotExist(err) {
+		return false, nil
+	}
+	if err != nil {
+		return false, err
+	}
+	defer file.Close()
+	var buf [512]byte
+	n, err := file.Read(buf[:])
+	if err != nil && !errors.Is(err, io.EOF) {
+		return false, err
+	}
+	line, _, _ := strings.Cut(string(buf[:n]), "\n")
+	annotations, ok := strings.CutPrefix(line, "## ")
+	if !ok {
+		return false, nil
+	}
+	for entry := range strings.SplitSeq(annotations, ";") {
+		if strings.TrimSpace(entry) == "workspace" {
+			return true, nil
+		}
+	}
+	return false, nil
+}
+
+func versionAtLeast(version string, major, minor int) bool {
+	var gotMajor, gotMinor int
+	if _, err := fmt.Sscanf(version, "%d.%d", &gotMajor, &gotMinor); err != nil {
+		return false
+	}
+	return gotMajor > major || gotMajor == major && gotMinor >= minor
+}
+
+func vendorUnsupportedError(mode string) error {
+	if mode == "" {
+		mode = "automatic vendor mode"
+	} else {
+		mode = "-mod=" + mode
+	}
+	return fmt.Errorf("%w (%s); select -mod=readonly or -mod=mod explicitly", ErrDriverVendorUnsupported, mode)
+}

--- a/cmd/internal/projectdriver/resolve_vendor_test.go
+++ b/cmd/internal/projectdriver/resolve_vendor_test.go
@@ -1,0 +1,302 @@
+/*
+ * Copyright (c) 2026 The XGo Authors (xgo.dev). All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package projectdriver
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/goplus/mod/modload"
+	"github.com/goplus/xgo/x/xgoprojs"
+)
+
+func TestEffectiveVendorModeMatchesGoCommandDefaults(t *testing.T) {
+	root := t.TempDir()
+	app := filepath.Join(root, "app")
+	vendorDir := filepath.Join(app, "vendor")
+	mustMkdirAll(t, vendorDir)
+	goMod := filepath.Join(app, "go.mod")
+	mustWriteFile(t, goMod, "module example.test/app\n\ngo 1.21\n")
+	loaded, err := modload.LoadFrom(goMod, filepath.Join(app, "gox.mod"))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	modulePolicy := GraphPolicy{GoWork: "off"}
+	if vendor, err := effectiveVendorMode(modulePolicy, goMod, loaded.File); err != nil || !vendor {
+		t.Fatalf("module vendor without modules.txt = %v, %v; want true", vendor, err)
+	}
+	mustWriteFile(t, filepath.Join(vendorDir, "modules.txt"), "## workspace\n")
+	if vendor, err := effectiveVendorMode(modulePolicy, goMod, loaded.File); err != nil || vendor {
+		t.Fatalf("workspace manifest outside workspace = %v, %v; want false", vendor, err)
+	}
+	mustWriteFile(t, filepath.Join(vendorDir, "modules.txt"), "# module manifest\n")
+	if vendor, err := effectiveVendorMode(modulePolicy, goMod, loaded.File); err != nil || !vendor {
+		t.Fatalf("module manifest in module mode = %v, %v; want true", vendor, err)
+	}
+
+	goWork := filepath.Join(root, "go.work")
+	mustWriteFile(t, goWork, "go 1.21\n\nuse ./app\n")
+	workspaceVendor := filepath.Join(root, "vendor")
+	mustMkdirAll(t, workspaceVendor)
+	mustWriteFile(t, filepath.Join(workspaceVendor, "modules.txt"), "# module manifest\n")
+	workspacePolicy := GraphPolicy{GoWork: goWork}
+	if vendor, err := effectiveVendorMode(workspacePolicy, goMod, loaded.File); err != nil || vendor {
+		t.Fatalf("module manifest in workspace mode = %v, %v; want false", vendor, err)
+	}
+	mustWriteFile(t, filepath.Join(workspaceVendor, "modules.txt"), "## workspace; future annotation\n")
+	if vendor, err := effectiveVendorMode(workspacePolicy, goMod, loaded.File); err != nil || !vendor {
+		t.Fatalf("Go 1.21 workspace manifest = %v, %v; want true", vendor, err)
+	}
+}
+
+func TestResolveVendorIgnoresUnmarkedDependencyDriver(t *testing.T) {
+	if testing.Short() {
+		t.Skip("invokes the host Go command")
+	}
+	app := t.TempDir()
+	project := filepath.Join(app, "game")
+	framework := filepath.Join(app, "framework")
+	mustMkdirAll(t, project)
+	mustMkdirAll(t, framework)
+	mustMkdirAll(t, filepath.Join(app, "vendor"))
+	mustWriteFile(t, filepath.Join(app, "vendor", "modules.txt"), "# vendored\n")
+	mustWriteFile(t, filepath.Join(app, "go.mod"), `module example.test/app
+
+go 1.25
+
+require example.test/framework v1.2.3
+
+replace example.test/framework => ./framework
+`)
+	mustWriteFile(t, filepath.Join(app, "gox.mod"), "xgo 1.8\nproject main.legacy Game example.test/app\n")
+	mustWriteFile(t, filepath.Join(framework, "go.mod"), "module example.test/framework\n\ngo 1.25\n")
+	mustWriteFile(t, filepath.Join(framework, "gox.mod"), "xgo 1.8\nproject main.foo Game example.test/framework\ndriver v1 example.test/framework/cmd/driver\n")
+	mustWriteFile(t, filepath.Join(project, "main.foo"), "// unmarked dependency driver-backed project\n")
+	t.Setenv("GOWORK", "off")
+	resolver, err := NewResolver(context.Background(), app, []string{"-mod=vendor"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, err = resolver.Resolve(context.Background(), &xgoprojs.DirProj{Dir: project})
+	if !errors.Is(err, ErrNotHandled) {
+		t.Fatalf("unmarked vendor dependency driver = %v, want ErrNotHandled", err)
+	}
+}
+
+func TestResolveDriverVendorFailsClosed(t *testing.T) {
+	if testing.Short() {
+		t.Skip("invokes the host Go command")
+	}
+	fixture := newDriverFixture(t)
+	mustMkdirAll(t, filepath.Join(fixture.app, "vendor"))
+	mustWriteFile(t, filepath.Join(fixture.app, "vendor", "modules.txt"), "# fixture\n")
+	_, err := fixture.resolver(t).Resolve(context.Background(), &xgoprojs.DirProj{Dir: fixture.project})
+	if !errors.Is(err, ErrDriverVendorUnsupported) {
+		t.Fatalf("vendor error = %v", err)
+	}
+}
+
+func TestResolveVendorClassifiesLegacyTargetsConservatively(t *testing.T) {
+	if testing.Short() {
+		t.Skip("invokes the host Go command")
+	}
+	tests := []struct {
+		name            string
+		class           bool
+		auto            bool
+		flags           []string
+		wantUnsupported bool
+	}{
+		{name: "main-explicit", flags: []string{"-mod=vendor"}},
+		{name: "main-automatic", auto: true},
+		{name: "class-explicit", class: true, flags: []string{"-mod=vendor"}, wantUnsupported: true},
+		{name: "class-automatic", class: true, auto: true, wantUnsupported: true},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			app := t.TempDir()
+			project := filepath.Join(app, "game")
+			mustMkdirAll(t, project)
+			mustMkdirAll(t, filepath.Join(app, "vendor"))
+			mustWriteFile(t, filepath.Join(app, "vendor", "modules.txt"), "# vendored\n")
+			if test.class {
+				framework := filepath.Join(app, "framework")
+				mustMkdirAll(t, framework)
+				mustWriteFile(t, filepath.Join(framework, "go.mod"), "module example.test/framework\n\ngo 1.25\n")
+				mustWriteFile(t, filepath.Join(framework, "gox.mod"), "xgo 1.8\nproject main.foo Game example.test/framework\n")
+				mustWriteFile(t, filepath.Join(app, "go.mod"), "module example.test/app\n\ngo 1.25\n\nrequire example.test/framework v1.2.3 //xgo:class\n\nreplace example.test/framework => ./framework\n")
+			} else {
+				mustWriteFile(t, filepath.Join(app, "go.mod"), "module example.test/app\n\ngo 1.25\n")
+				mustWriteFile(t, filepath.Join(app, "gox.mod"), "xgo 1.8\nproject main.foo Game example.test/app\n")
+			}
+			mustWriteFile(t, filepath.Join(project, "main.foo"), "// legacy project\n")
+			t.Setenv("GOWORK", "off")
+			resolver, err := NewResolver(context.Background(), app, test.flags)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if test.auto {
+				resolver.policy.graph.ModMode = ""
+			}
+			_, err = resolver.Resolve(context.Background(), &xgoprojs.DirProj{Dir: project})
+			if test.wantUnsupported {
+				if !errors.Is(err, ErrDriverVendorUnsupported) {
+					t.Fatalf("external class vendor target = %v, want ErrDriverVendorUnsupported", err)
+				}
+			} else if !errors.Is(err, ErrNotHandled) {
+				t.Fatalf("main-module legacy vendor target = %v, want ErrNotHandled", err)
+			}
+		})
+	}
+}
+
+func TestResolveDriverTargetStillRejectsVendor(t *testing.T) {
+	if testing.Short() {
+		t.Skip("invokes the host Go command")
+	}
+	app := t.TempDir()
+	project := filepath.Join(app, "game")
+	framework := filepath.Join(app, "framework")
+	mustMkdirAll(t, project)
+	mustMkdirAll(t, framework)
+	mustMkdirAll(t, filepath.Join(app, "vendor"))
+	mustWriteFile(t, filepath.Join(app, "vendor", "modules.txt"), "# vendored\n")
+	mustWriteFile(t, filepath.Join(app, "go.mod"), "module example.test/app\n\ngo 1.25\n\nrequire example.test/framework v1.2.3 //xgo:class\n\nreplace example.test/framework => ./framework\n")
+	mustWriteFile(t, filepath.Join(framework, "go.mod"), "module example.test/framework\n\ngo 1.25\n")
+	mustWriteFile(t, filepath.Join(framework, "gox.mod"), "xgo 1.8\nproject main.foo Game example.test/framework\ndriver v1 example.test/framework/cmd/driver\n")
+	mustWriteFile(t, filepath.Join(project, "main.foo"), "// driver-backed project\n")
+	t.Setenv("GOWORK", "off")
+	resolver, err := NewResolver(context.Background(), app, []string{"-mod=vendor"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, err = resolver.Resolve(context.Background(), &xgoprojs.DirProj{Dir: project})
+	if !errors.Is(err, ErrDriverVendorUnsupported) {
+		t.Fatalf("driver vendor target = %v", err)
+	}
+}
+
+func TestResolveRealModuleVendorExternalClassFailsClosed(t *testing.T) {
+	if testing.Short() {
+		t.Skip("invokes the host Go command")
+	}
+	root := t.TempDir()
+	app := filepath.Join(root, "app")
+	project := filepath.Join(app, "game")
+	framework := filepath.Join(root, "framework")
+	mustMkdirAll(t, project)
+	mustMkdirAll(t, filepath.Join(framework, "cmd", "driver"))
+	mustWriteFile(t, filepath.Join(app, "go.mod"), `module example.test/app
+
+go 1.25
+
+require example.test/framework v1.2.3 //xgo:class
+
+replace example.test/framework => ../framework
+`)
+	mustWriteFile(t, filepath.Join(app, "main.go"), "package app\n\nimport _ \"example.test/framework/cmd/driver\"\n")
+	mustWriteFile(t, filepath.Join(framework, "go.mod"), "module example.test/framework\n\ngo 1.25\n")
+	mustWriteFile(t, filepath.Join(framework, "gox.mod"), `xgo 1.8
+project main.foo Game example.test/framework
+driver v1 example.test/framework/cmd/driver
+`)
+	mustWriteFile(t, filepath.Join(framework, "cmd", "driver", "driver.go"), "package driver\n")
+	mustWriteFile(t, filepath.Join(project, "main.foo"), "// driver-backed project\n")
+	mustRunGo(t, app, "off", "mod", "vendor")
+	vendoredFramework := filepath.Join(app, "vendor", "example.test", "framework")
+	if _, err := os.Stat(filepath.Join(vendoredFramework, "cmd", "driver", "driver.go")); err != nil {
+		t.Fatalf("real vendor snapshot omitted imported driver package: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(vendoredFramework, "gox.mod")); !os.IsNotExist(err) {
+		t.Fatalf("real vendor snapshot unexpectedly contains module-root gox.mod: %v", err)
+	}
+	t.Setenv("GOWORK", "off")
+	resolver, err := NewResolver(context.Background(), app, []string{"-mod=vendor"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	for name, target := range map[string]xgoprojs.Proj{
+		"directory": &xgoprojs.DirProj{Dir: project},
+		"package":   &xgoprojs.PkgPathProj{Path: "example.test/app/game"},
+	} {
+		t.Run(name, func(t *testing.T) {
+			if _, err := resolver.Resolve(context.Background(), target); !errors.Is(err, ErrDriverVendorUnsupported) {
+				t.Fatalf("real vendored class target = %v, want ErrDriverVendorUnsupported", err)
+			}
+		})
+	}
+}
+
+func TestResolveRealModuleVendorPlainPackageUsesLegacyPath(t *testing.T) {
+	if testing.Short() {
+		t.Skip("invokes the host Go command")
+	}
+	root := t.TempDir()
+	app := filepath.Join(root, "app")
+	dependency := filepath.Join(root, "dependency")
+	mustMkdirAll(t, app)
+	mustMkdirAll(t, dependency)
+	mustWriteFile(t, filepath.Join(app, "go.mod"), "module example.test/app\n\ngo 1.25\n\nrequire example.test/dependency v1.0.0\n\nreplace example.test/dependency => ../dependency\n")
+	mustWriteFile(t, filepath.Join(app, "main.go"), "package app\n\nimport _ \"example.test/dependency\"\n")
+	mustWriteFile(t, filepath.Join(dependency, "go.mod"), "module example.test/dependency\n\ngo 1.25\n")
+	mustWriteFile(t, filepath.Join(dependency, "dependency.go"), "package dependency\n")
+	mustRunGo(t, app, "off", "mod", "vendor")
+	t.Setenv("GOWORK", "off")
+	resolver, err := NewResolver(context.Background(), app, []string{"-mod=vendor"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := resolver.Resolve(context.Background(), &xgoprojs.PkgPathProj{Path: "example.test/app"}); !errors.Is(err, ErrNotHandled) {
+		t.Fatalf("plain vendored package = %v, want ErrNotHandled", err)
+	}
+}
+
+func TestResolveRealWorkspaceVendorClassFailsClosed(t *testing.T) {
+	if testing.Short() {
+		t.Skip("invokes the host Go command")
+	}
+	root := t.TempDir()
+	app := filepath.Join(root, "app")
+	project := filepath.Join(app, "game")
+	framework := filepath.Join(root, "framework")
+	mustMkdirAll(t, project)
+	mustMkdirAll(t, filepath.Join(framework, "cmd", "driver"))
+	mustWriteFile(t, filepath.Join(root, "go.work"), "go 1.25\n\nuse ./app\n\nreplace example.test/framework => ./framework\n")
+	mustWriteFile(t, filepath.Join(app, "go.mod"), "module example.test/app\n\ngo 1.25\n\nrequire example.test/framework v1.2.3 //xgo:class\n")
+	mustWriteFile(t, filepath.Join(app, "main.go"), "package app\n\nimport _ \"example.test/framework/cmd/driver\"\n")
+	mustWriteFile(t, filepath.Join(framework, "go.mod"), "module example.test/framework\n\ngo 1.25\n")
+	mustWriteFile(t, filepath.Join(framework, "gox.mod"), "xgo 1.8\nproject main.foo Game example.test/framework\ndriver v1 example.test/framework/cmd/driver\n")
+	mustWriteFile(t, filepath.Join(framework, "cmd", "driver", "driver.go"), "package driver\n")
+	mustWriteFile(t, filepath.Join(project, "main.foo"), "// driver-backed project\n")
+	goWork := filepath.Join(root, "go.work")
+	mustRunGo(t, root, goWork, "work", "vendor")
+	if _, err := os.Stat(filepath.Join(root, "vendor", "modules.txt")); err != nil {
+		t.Fatalf("workspace vendor snapshot missing modules.txt: %v", err)
+	}
+	t.Setenv("GOWORK", goWork)
+	resolver, err := NewResolver(context.Background(), app, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := resolver.Resolve(context.Background(), &xgoprojs.DirProj{Dir: project}); !errors.Is(err, ErrDriverVendorUnsupported) {
+		t.Fatalf("workspace vendored class target = %v, want ErrDriverVendorUnsupported", err)
+	}
+}

--- a/cmd/internal/projectdriver/resolve_vendor_workspace.go
+++ b/cmd/internal/projectdriver/resolve_vendor_workspace.go
@@ -1,0 +1,157 @@
+/*
+ * Copyright (c) 2026 The XGo Authors (xgo.dev). All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package projectdriver
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	gomodfile "golang.org/x/mod/modfile"
+)
+
+type workspaceVendorMember struct {
+	modulePath string
+	root       string
+	goMod      string
+}
+
+// probeVendorWorkspacePackage handles XGo-only packages in vendor mode.
+// Only go.work use members are eligible.
+func (r *Resolver) probeVendorWorkspacePackage(ctx context.Context, importPath string, recursive bool) (bool, error) {
+	members, err := loadWorkspaceVendorMembers(r.policy.graph.GoWork)
+	if err != nil {
+		return false, err
+	}
+	var selected *workspaceVendorMember
+	for i := range members {
+		member := &members[i]
+		if !moduleContainsPackage(member.modulePath, importPath) {
+			continue
+		}
+		if selected == nil || len(member.modulePath) > len(selected.modulePath) {
+			selected = member
+		}
+	}
+	if selected == nil {
+		return false, fmt.Errorf("%w: package target %q is not owned by a workspace member", vendorUnsupportedError(string(r.policy.graph.ModMode)), importPath)
+	}
+
+	loaded, err := loadDriverModule(selected.goMod, filepath.Join(selected.root, "gox.mod"))
+	if err != nil {
+		return false, fmt.Errorf("load workspace member %q metadata: %w", selected.modulePath, err)
+	}
+	if loaded.Path() != selected.modulePath {
+		return false, fmt.Errorf("workspace member %q module path changed to %q during driver discovery", selected.modulePath, loaded.Path())
+	}
+	if classPath := externalClassModule(loaded); classPath != "" {
+		return false, r.vendorClassMetadataError(classPath)
+	}
+	suffix := strings.TrimPrefix(importPath, selected.modulePath)
+	candidate := filepath.Join(selected.root, filepath.FromSlash(strings.TrimPrefix(suffix, "/")))
+	projectDir, err := canonicalExistingDir(candidate)
+	if err != nil {
+		return false, fmt.Errorf("%w: package target %q has no classifiable workspace directory: %v", vendorUnsupportedError(string(r.policy.graph.ModMode)), importPath, err)
+	}
+	if !pathWithin(selected.root, projectDir) {
+		return false, fmt.Errorf("package target %q escapes workspace module %q", importPath, selected.modulePath)
+	}
+	ownerGoMod, err := goModForDir(ctx, r.policy.graph, projectDir)
+	if err != nil {
+		return false, fmt.Errorf("resolve package target %q module ownership: %w", importPath, err)
+	}
+	if ownerGoMod == "" || ownerGoMod == os.DevNull {
+		return false, fmt.Errorf("package target %q has no module ownership", importPath)
+	}
+	same, err := sameFile(selected.goMod, ownerGoMod)
+	if err != nil {
+		return false, fmt.Errorf("resolve package target %q module ownership: %w", importPath, err)
+	}
+	if !same {
+		return false, fmt.Errorf("package target %q crosses a nested module boundary", importPath)
+	}
+	return matchVendorProjects(projectDir, loaded.Projects(), recursive)
+}
+
+func loadWorkspaceVendorMembers(goWork string) ([]workspaceVendorMember, error) {
+	data, err := os.ReadFile(goWork)
+	if err != nil {
+		return nil, fmt.Errorf("read workspace file %q: %w", goWork, err)
+	}
+	work, err := gomodfile.ParseWork(goWork, data, nil)
+	if err != nil {
+		return nil, err
+	}
+	workRoot := filepath.Dir(goWork)
+	members := make([]workspaceVendorMember, 0, len(work.Use))
+	seenRoots := make(map[string]struct{}, len(work.Use))
+	seenModules := make(map[string]string, len(work.Use))
+	for _, use := range work.Use {
+		if use == nil || use.Path == "" {
+			return nil, fmt.Errorf("workspace %q contains an empty use path", goWork)
+		}
+		root := filepath.FromSlash(use.Path)
+		if !filepath.IsAbs(root) {
+			root = filepath.Join(workRoot, root)
+		}
+		root, err = canonicalExistingDir(root)
+		if err != nil {
+			return nil, fmt.Errorf("resolve workspace member %q: %w", use.Path, err)
+		}
+		if _, duplicate := seenRoots[root]; duplicate {
+			return nil, fmt.Errorf("workspace %q contains duplicate member directory %q", goWork, root)
+		}
+		seenRoots[root] = struct{}{}
+
+		goModPath := filepath.Join(root, "go.mod")
+		info, err := os.Lstat(goModPath)
+		if err != nil {
+			return nil, fmt.Errorf("inspect workspace member go.mod %q: %w", goModPath, err)
+		}
+		if info.Mode()&os.ModeSymlink != 0 || !info.Mode().IsRegular() {
+			return nil, fmt.Errorf("workspace member go.mod %q is not a regular non-symlink file", goModPath)
+		}
+		originalGoModPath := goModPath
+		goModPath, err = canonicalExistingFile(originalGoModPath)
+		if err != nil {
+			return nil, fmt.Errorf("resolve workspace member go.mod %q: %w", originalGoModPath, err)
+		}
+		if filepath.Dir(goModPath) != root {
+			return nil, fmt.Errorf("workspace member go.mod %q escapes member root %q", goModPath, root)
+		}
+		goModData, err := os.ReadFile(goModPath)
+		if err != nil {
+			return nil, fmt.Errorf("read workspace member go.mod %q: %w", goModPath, err)
+		}
+		parsed, err := gomodfile.Parse(goModPath, goModData, nil)
+		if err != nil {
+			return nil, err
+		}
+		if parsed.Module == nil || parsed.Module.Mod.Path == "" {
+			return nil, fmt.Errorf("workspace member %q has no module path", root)
+		}
+		modulePath := parsed.Module.Mod.Path
+		if previous, duplicate := seenModules[modulePath]; duplicate {
+			return nil, fmt.Errorf("workspace module %q is declared by both %q and %q", modulePath, previous, root)
+		}
+		seenModules[modulePath] = root
+		members = append(members, workspaceVendorMember{modulePath: modulePath, root: root, goMod: goModPath})
+	}
+	return members, nil
+}

--- a/cmd/internal/projectdriver/resolve_vendor_workspace_test.go
+++ b/cmd/internal/projectdriver/resolve_vendor_workspace_test.go
@@ -1,0 +1,230 @@
+/*
+ * Copyright (c) 2026 The XGo Authors (xgo.dev). All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package projectdriver
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+
+	"github.com/goplus/mod/modfile"
+	"github.com/goplus/xgo/x/xgoprojs"
+)
+
+func TestResolveWorkspaceVendorPackageUsesTargetModuleMetadata(t *testing.T) {
+	if testing.Short() {
+		t.Skip("invokes the host Go command")
+	}
+	root := t.TempDir()
+	caller := filepath.Join(root, "caller")
+	driverModule := filepath.Join(root, "driver")
+	driverProject := filepath.Join(driverModule, "game")
+	legacyModule := filepath.Join(root, "legacy")
+	legacyProject := filepath.Join(legacyModule, "game")
+	mustMkdirAll(t, caller)
+	mustMkdirAll(t, driverProject)
+	mustMkdirAll(t, legacyProject)
+	mustWriteFile(t, filepath.Join(root, "go.work"), `go 1.25
+
+use (
+	./caller
+	./driver
+	./legacy
+)
+`)
+	mustWriteFile(t, filepath.Join(caller, "go.mod"), "module example.test/caller\n\ngo 1.25\n")
+	mustWriteFile(t, filepath.Join(caller, "caller.go"), "package caller\n")
+	mustWriteFile(t, filepath.Join(driverModule, "go.mod"), "module example.test/driver\n\ngo 1.25\n")
+	mustWriteFile(t, filepath.Join(driverModule, "gox.mod"), "xgo 1.8\nproject main.foo Game example.test/driver\ndriver v1 example.test/driver/cmd/driver\n")
+	mustWriteFile(t, filepath.Join(driverProject, "main.foo"), "// driver-backed project\n")
+	mustWriteFile(t, filepath.Join(legacyModule, "go.mod"), "module example.test/legacy\n\ngo 1.25\n")
+	mustWriteFile(t, filepath.Join(legacyModule, "gox.mod"), "xgo 1.8\nproject main.legacy Game example.test/legacy\n")
+	mustWriteFile(t, filepath.Join(legacyProject, "main.legacy"), "// legacy project\n")
+	goWork := filepath.Join(root, "go.work")
+	t.Setenv("GOWORK", goWork)
+	resolver, err := NewResolver(context.Background(), caller, []string{"-mod=vendor"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := resolver.Resolve(context.Background(), &xgoprojs.PkgPathProj{Path: "example.test/driver/game"}); !errors.Is(err, ErrDriverVendorUnsupported) {
+		t.Fatalf("workspace driver package in vendor mode = %v, want ErrDriverVendorUnsupported", err)
+	}
+	if _, err := resolver.Resolve(context.Background(), &xgoprojs.PkgPathProj{Path: "example.test/legacy/game"}); !errors.Is(err, ErrNotHandled) {
+		t.Fatalf("workspace legacy package in vendor mode = %v, want ErrNotHandled", err)
+	}
+
+	if driver, err := resolver.probeVendorWorkspacePackage(context.Background(), "example.test/driver/game", false); err != nil || !driver {
+		t.Fatalf("workspace fallback driver classification = %v, %v; want true", driver, err)
+	}
+	if driver, err := resolver.probeVendorWorkspacePackage(context.Background(), "example.test/legacy/game", false); err != nil || driver {
+		t.Fatalf("workspace fallback legacy classification = %v, %v; want false", driver, err)
+	}
+}
+
+func TestProbeVendorWorkspacePackageRejectsExternalClassWithoutReadingReplacement(t *testing.T) {
+	if testing.Short() {
+		t.Skip("invokes the host Go command")
+	}
+	root := t.TempDir()
+	caller := filepath.Join(root, "caller")
+	member := filepath.Join(root, "member")
+	project := filepath.Join(member, "game")
+	for _, dir := range []string{caller, project} {
+		mustMkdirAll(t, dir)
+	}
+	mustWriteFile(t, filepath.Join(root, "go.work"), `go 1.25
+
+use (
+	./caller
+	./member
+)
+
+replace example.test/framework => ./missing-live-replacement
+`)
+	mustWriteFile(t, filepath.Join(caller, "go.mod"), "module example.test/caller\n\ngo 1.25\n")
+	mustWriteFile(t, filepath.Join(member, "go.mod"), "module example.test/member\n\ngo 1.25\n\nrequire example.test/framework v1.0.0 //xgo:class\n")
+	mustWriteFile(t, filepath.Join(member, "gox.mod"), "xgo 1.8\nproject main.legacy Game example.test/member\n")
+	mustWriteFile(t, filepath.Join(project, "main.legacy"), "// indeterminate external class project\n")
+
+	goWork := filepath.Join(root, "go.work")
+	t.Setenv("GOWORK", goWork)
+	resolver, err := NewResolver(context.Background(), caller, []string{"-mod=vendor"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := resolver.probeVendorWorkspacePackage(context.Background(), "example.test/member/game", false); !errors.Is(err, ErrDriverVendorUnsupported) {
+		t.Fatalf("workspace external class classification = %v, want ErrDriverVendorUnsupported", err)
+	}
+}
+
+func TestProbeVendorWorkspacePackageUsesLongestMemberAndRejectsNestedModule(t *testing.T) {
+	if testing.Short() {
+		t.Skip("invokes the host Go command")
+	}
+	root := t.TempDir()
+	caller := filepath.Join(root, "caller")
+	parent := filepath.Join(root, "parent")
+	child := filepath.Join(root, "child")
+	childProject := filepath.Join(child, "game")
+	nested := filepath.Join(parent, "nested")
+	nestedProject := filepath.Join(nested, "game")
+	for _, dir := range []string{caller, parent, childProject, nestedProject} {
+		mustMkdirAll(t, dir)
+	}
+	mustWriteFile(t, filepath.Join(root, "go.work"), "go 1.25\n\nuse (\n\t./caller\n\t./parent\n\t./child\n)\n")
+	mustWriteFile(t, filepath.Join(caller, "go.mod"), "module example.test/caller\n\ngo 1.25\n")
+	mustWriteFile(t, filepath.Join(parent, "go.mod"), "module example.test/shared\n\ngo 1.25\n")
+	mustWriteFile(t, filepath.Join(parent, "gox.mod"), "xgo 1.8\nproject main.legacy Game example.test/shared\n")
+	mustWriteFile(t, filepath.Join(child, "go.mod"), "module example.test/shared/sub\n\ngo 1.25\n")
+	mustWriteFile(t, filepath.Join(child, "gox.mod"), "xgo 1.8\nproject main.foo Game example.test/shared/sub\ndriver v1 example.test/shared/sub/cmd/driver\n")
+	mustWriteFile(t, filepath.Join(childProject, "main.foo"), "// driver-backed project in longest module match\n")
+	mustWriteFile(t, filepath.Join(nested, "go.mod"), "module example.test/nested\n\ngo 1.25\n")
+	mustWriteFile(t, filepath.Join(nestedProject, "main.legacy"), "// nested module project\n")
+
+	goWork := filepath.Join(root, "go.work")
+	t.Setenv("GOWORK", goWork)
+	resolver, err := NewResolver(context.Background(), caller, []string{"-mod=vendor"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if driver, err := resolver.probeVendorWorkspacePackage(context.Background(), "example.test/shared/sub/game", false); err != nil || !driver {
+		t.Fatalf("longest workspace member classification = %v, %v; want true", driver, err)
+	}
+	if _, err := resolver.probeVendorWorkspacePackage(context.Background(), "example.test/shared/nested/game", false); err == nil {
+		t.Fatal("workspace package crossing a nested module boundary was classified")
+	}
+}
+
+func TestResolveVendorRecursivePatternFailsClosed(t *testing.T) {
+	if testing.Short() {
+		t.Skip("invokes the host Go command")
+	}
+	app := t.TempDir()
+	project := filepath.Join(app, "game")
+	mustMkdirAll(t, project)
+	mustWriteFile(t, filepath.Join(app, "go.mod"), "module example.test/app\n\ngo 1.25\n")
+	mustWriteFile(t, filepath.Join(app, "gox.mod"), "xgo 1.8\nproject main.foo Game example.test/app\ndriver v1 example.test/app/cmd/driver\n")
+	mustWriteFile(t, filepath.Join(app, "app.go"), "package app\n")
+	mustWriteFile(t, filepath.Join(project, "main.foo"), "// driver-backed project\n")
+	t.Setenv("GOWORK", "off")
+	resolver, err := NewResolver(context.Background(), app, []string{"-mod=vendor"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	for name, target := range map[string]xgoprojs.Proj{
+		"directory": &xgoprojs.DirProj{Dir: filepath.Join(app, "...")},
+		"package":   &xgoprojs.PkgPathProj{Path: "example.test/app/..."},
+	} {
+		t.Run(name, func(t *testing.T) {
+			if _, err := resolver.Resolve(context.Background(), target); !errors.Is(err, ErrDriverVendorUnsupported) {
+				t.Fatalf("recursive vendor target = %v, want ErrDriverVendorUnsupported", err)
+			}
+		})
+	}
+}
+
+func TestVendorDriverProbePropagatesFilesystemErrors(t *testing.T) {
+	projects := []*modfile.Project{{Driver: &modfile.Driver{Protocol: "v1", Package: "example.test/driver"}}}
+	if _, err := hasDriverProject(filepath.Join(t.TempDir(), "missing"), projects); err == nil {
+		t.Fatal("missing project directory was classified as no driver")
+	}
+
+	if runtime.GOOS == "windows" {
+		t.Skip("self-referential symlink setup is not portable to Windows")
+	}
+	app := t.TempDir()
+	mustWriteFile(t, filepath.Join(app, "go.mod"), "module example.test/app\n\ngo 1.25\n")
+	mustWriteFile(t, filepath.Join(app, "gox.mod"), "xgo 1.8\nproject main.foo Game example.test/app\n")
+	mustWriteFile(t, filepath.Join(app, "main.foo"), "// legacy project\n")
+	if err := os.Symlink("vendor", filepath.Join(app, "vendor")); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("GOWORK", "off")
+	resolver, err := NewResolver(context.Background(), app, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := resolver.Resolve(context.Background(), &xgoprojs.DirProj{Dir: app}); err == nil || errors.Is(err, ErrNotHandled) {
+		t.Fatalf("vendor manifest I/O failure = %v, want explicit error", err)
+	}
+}
+
+func TestVendorDriverProbeRejectsProjectSymlinksAndSpecialFiles(t *testing.T) {
+	projects := []*modfile.Project{{Ext: ".foo", FullExt: "main.foo", Driver: &modfile.Driver{Protocol: "v1", Package: "example.test/driver"}}}
+	for _, special := range []string{"symlink", "directory"} {
+		t.Run(special, func(t *testing.T) {
+			dir := t.TempDir()
+			project := filepath.Join(dir, "main.foo")
+			if special == "symlink" {
+				backing := filepath.Join(dir, "backing")
+				mustWriteFile(t, backing, "// project\n")
+				if err := os.Symlink(backing, project); err != nil {
+					t.Skipf("symlink unavailable: %v", err)
+				}
+			} else if err := os.Mkdir(project, 0o755); err != nil {
+				t.Fatal(err)
+			}
+			if _, err := hasDriverProject(dir, projects); err == nil || !strings.Contains(err.Error(), "regular non-symlink") {
+				t.Fatalf("hasDriverProject() error = %v", err)
+			}
+		})
+	}
+}

--- a/cmd/internal/projectdriver/resolve_versioned.go
+++ b/cmd/internal/projectdriver/resolve_versioned.go
@@ -1,0 +1,261 @@
+/*
+ * Copyright (c) 2026 The XGo Authors (xgo.dev). All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package projectdriver
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+
+	"golang.org/x/mod/module"
+)
+
+// versionedPackageHasDriver classifies the requested version in an isolated graph.
+// Caller graph metadata is deliberately not reused.
+func (r *Resolver) versionedPackageHasDriver(ctx context.Context, target string) (bool, error) {
+	importPath, query, ok := splitVersionedPackageTarget(target)
+	if !ok {
+		return false, nil
+	}
+
+	probeDir, err := os.MkdirTemp("", "xgo-driver-version-probe-")
+	if err != nil {
+		return false, fmt.Errorf("create versioned package graph probe: %w", err)
+	}
+	defer os.RemoveAll(probeDir)
+	if err := os.WriteFile(filepath.Join(probeDir, "go.mod"), []byte("module xgo.dev/projectdriver/versionprobe\n\ngo 1.25\n"), 0o600); err != nil {
+		return false, fmt.Errorf("write versioned package graph probe: %w", err)
+	}
+	probeEnv := replaceEnv(os.Environ(), "GOWORK", "off")
+	probeEnv = replaceEnv(probeEnv, "GOFLAGS", "-mod=mod")
+	probePolicy := GraphPolicy{
+		GoCommand: r.policy.graph.GoCommand,
+		GoWork:    "off",
+		ModMode:   modModeMod,
+		WorkDir:   probeDir,
+	}
+	probe, err := r.probeVersionedPackage(ctx, probeDir, importPath, query, probeEnv, probePolicy)
+	if err != nil {
+		if cause := context.Cause(ctx); cause != nil {
+			return false, cause
+		}
+		return false, fmt.Errorf("resolve versioned package %q module: %w", target, err)
+	}
+	if probe.state != versionedProbeMatch {
+		return false, nil
+	}
+	listed := probe.module
+	if err := listed.Validate(); err != nil {
+		return false, fmt.Errorf("validate versioned package %q module: %w", target, err)
+	}
+	probeMod := fmt.Sprintf("module xgo.dev/projectdriver/versionprobe\n\ngo 1.25\n\nrequire %s %s //xgo:class\n", listed.Selected.Path, listed.Selected.Version)
+	if err := os.WriteFile(filepath.Join(probeDir, "go.mod"), []byte(probeMod), 0o600); err != nil {
+		return false, fmt.Errorf("write versioned package graph probe: %w", err)
+	}
+	return r.versionedGraphHasDriver(ctx, target, probeDir, probe.projectDir, probePolicy, listed)
+}
+
+func (r *Resolver) probeVersionedPackage(ctx context.Context, probeDir, importPath, query string, env []string, policy GraphPolicy) (versionedProbeResult, error) {
+	get := exec.CommandContext(ctx, r.policy.graph.GoCommand, "get", importPath+"@"+query)
+	get.Dir, get.Env, get.Stdout = probeDir, env, io.Discard
+	if err := get.Run(); err == nil {
+		if pkg, err := listPackageTarget(ctx, importPath, probeDir, policy); err == nil && pkg.ImportPath == importPath && pkg.Module != nil && pkg.Dir != "" {
+			listed, err := normalizeListedModule(*pkg.Module)
+			if err == nil {
+				projectDir, err := canonicalExistingDir(pkg.Dir)
+				if err == nil && pathWithin(listed.Effective().Dir, projectDir) {
+					return versionedProbeResult{state: versionedProbeMatch, module: listed, projectDir: projectDir}, nil
+				}
+			}
+		}
+	}
+	if cause := context.Cause(ctx); cause != nil {
+		return versionedProbeResult{}, cause
+	}
+	result, err := r.resolveVersionedModuleSource(ctx, probeDir, importPath, query, env)
+	if cause := context.Cause(ctx); cause != nil {
+		return versionedProbeResult{}, cause
+	}
+	return result, err
+}
+
+func (r *Resolver) versionedGraphHasDriver(ctx context.Context, target, probeDir, projectDir string, policy GraphPolicy, listed ResolvedModule) (bool, error) {
+	graph, err := loadEffectiveGraph(ctx, probeDir, policy)
+	if err != nil {
+		if cause := context.Cause(ctx); cause != nil {
+			return false, cause
+		}
+		return false, fmt.Errorf("load versioned package %q graph: %w", target, err)
+	}
+	requested, ok := graph.Modules[listed.Selected.Path]
+	if !ok || !sameModuleSelection(requested, listed) {
+		return false, fmt.Errorf("versioned package %q graph selected unexpected module %#v", target, requested)
+	}
+	if requested.Effective().Dir == "" || requested.Effective().GoMod == "" {
+		// `go list -find` already supplied the authoritative source fields.
+		requested = listed
+		graph.Modules[listed.Selected.Path] = requested
+	}
+	graph, err = retargetEffectiveGraph(ctx, graph, requested, policy)
+	if err != nil {
+		if cause := context.Cause(ctx); cause != nil {
+			return false, cause
+		}
+		return false, fmt.Errorf("retarget versioned package %q graph: %w", target, err)
+	}
+	module, hasClass, err := loadResolvedClasses(graph)
+	if err != nil {
+		return false, fmt.Errorf("load versioned package %q driver metadata: %w", target, err)
+	}
+	if !hasClass {
+		return false, nil
+	}
+	_, info, _, err := findProjectFile(projectDir, module)
+	if err != nil {
+		return false, fmt.Errorf("classify versioned package %q: %w", target, err)
+	}
+	return info != nil && info.Project != nil && info.Project.Driver != nil, nil
+}
+
+type versionedProbeState uint8
+
+const (
+	versionedProbeMiss versionedProbeState = iota
+	versionedProbeMatch
+	versionedProbeNestedBoundary
+)
+
+type versionedProbeResult struct {
+	state      versionedProbeState
+	module     ResolvedModule
+	projectDir string
+}
+
+func (r *Resolver) resolveVersionedModuleSource(ctx context.Context, probeDir, importPath, query string, env []string) (versionedProbeResult, error) {
+	parts := strings.Split(importPath, "/")
+	for length := len(parts); length > 0; length-- {
+		candidate := strings.Join(parts[:length], "/")
+		if err := module.CheckPath(candidate); err != nil {
+			continue
+		}
+		result, err := r.downloadVersionedModule(ctx, probeDir, candidate, importPath, query, env)
+		if err != nil {
+			return versionedProbeResult{}, err
+		}
+		if result.state == versionedProbeNestedBoundary || result.state == versionedProbeMatch {
+			return result, nil
+		}
+	}
+	return versionedProbeResult{state: versionedProbeMiss}, nil
+}
+
+func (r *Resolver) downloadVersionedModule(ctx context.Context, probeDir, candidate, importPath, query string, env []string) (versionedProbeResult, error) {
+	cmd := exec.CommandContext(ctx, r.policy.graph.GoCommand, "mod", "download", "-json", candidate+"@"+query)
+	cmd.Dir = probeDir
+	cmd.Env = env
+	var stdout bytes.Buffer
+	cmd.Stdout = &stdout
+	if err := cmd.Run(); err != nil {
+		if cause := context.Cause(ctx); cause != nil {
+			return versionedProbeResult{}, cause
+		}
+		return versionedProbeResult{state: versionedProbeMiss}, nil
+	}
+	var downloaded goDownloadModule
+	if err := json.Unmarshal(stdout.Bytes(), &downloaded); err != nil {
+		return versionedProbeResult{}, fmt.Errorf("decode downloaded module %q: %w", candidate, err)
+	}
+	if downloaded.Error != "" || downloaded.Path != candidate || downloaded.Version == "" || downloaded.Dir == "" || downloaded.GoMod == "" {
+		return versionedProbeResult{state: versionedProbeMiss}, nil
+	}
+	sourceDir, goMod, err := canonicalModuleSource(downloaded.Path, downloaded.Dir, downloaded.GoMod)
+	if err != nil {
+		return versionedProbeResult{state: versionedProbeMiss}, nil
+	}
+	state, projectDir, err := versionedModulePackageDir(sourceDir, downloaded.Path, importPath)
+	if err != nil {
+		return versionedProbeResult{}, err
+	}
+	if state != versionedProbeMatch {
+		return versionedProbeResult{state: state}, nil
+	}
+	return versionedProbeResult{
+		state:      versionedProbeMatch,
+		projectDir: projectDir,
+		module: ResolvedModule{
+			Selected: ModuleRef{
+				Path:    downloaded.Path,
+				Version: downloaded.Version,
+				Dir:     sourceDir,
+				GoMod:   goMod,
+			},
+		},
+	}, nil
+}
+
+func versionedModulePackageDir(moduleRoot, modulePath, importPath string) (versionedProbeState, string, error) {
+	if !moduleContainsPackage(modulePath, importPath) {
+		return versionedProbeMiss, "", nil
+	}
+	rel := strings.TrimPrefix(importPath, modulePath)
+	rel = strings.TrimPrefix(rel, "/")
+	projectDir, err := canonicalExistingDir(filepath.Join(moduleRoot, filepath.FromSlash(rel)))
+	if err != nil {
+		if os.IsNotExist(err) {
+			return versionedProbeMiss, "", nil
+		}
+		return versionedProbeMiss, "", err
+	}
+	if !pathWithin(moduleRoot, projectDir) {
+		return versionedProbeMiss, "", fmt.Errorf("package %q escapes module %q", importPath, modulePath)
+	}
+	for current := projectDir; current != moduleRoot; current = filepath.Dir(current) {
+		if _, err := os.Stat(filepath.Join(current, "go.mod")); err == nil {
+			return versionedProbeNestedBoundary, "", nil
+		} else if !os.IsNotExist(err) {
+			return versionedProbeMiss, "", err
+		}
+	}
+	return versionedProbeMatch, projectDir, nil
+}
+
+func splitVersionedPackageTarget(target string) (importPath, query string, ok bool) {
+	index := strings.LastIndexByte(target, '@')
+	if index <= 0 || index == len(target)-1 {
+		return "", "", false
+	}
+	return target[:index], target[index+1:], true
+}
+
+func sameModuleSelection(a, b ResolvedModule) bool {
+	if a.Main != b.Main || a.Selected.Path != b.Selected.Path || a.Selected.Version != b.Selected.Version {
+		return false
+	}
+	if (a.Replace == nil) != (b.Replace == nil) {
+		return false
+	}
+	if a.Replace == nil {
+		return true
+	}
+	return a.Replace.Path == b.Replace.Path && a.Replace.Version == b.Replace.Version
+}

--- a/cmd/internal/projectdriver/resolve_versioned_test.go
+++ b/cmd/internal/projectdriver/resolve_versioned_test.go
@@ -1,0 +1,215 @@
+/*
+ * Copyright (c) 2026 The XGo Authors (xgo.dev). All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package projectdriver
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/url"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"testing"
+
+	"github.com/goplus/xgo/x/xgoprojs"
+	"golang.org/x/mod/module"
+	modzip "golang.org/x/mod/zip"
+)
+
+func TestResolveVersionedPackageUsesRequestedVersionMetadata(t *testing.T) {
+	if testing.Short() {
+		t.Skip("invokes the host Go command")
+	}
+	proxy := t.TempDir()
+	writeModuleProxy(t, proxy, "example.test/framework", map[string]map[string]string{
+		"v1.0.0": {
+			"go.mod":               "module example.test/framework\n\ngo 1.25\n",
+			"gox.mod":              "xgo 1.8\nproject main.foo Game example.test/framework\ndriver v1 example.test/framework/cmd/driver\n",
+			"cmd/driver/driver.go": "package driver\n",
+		},
+	})
+	writeModuleProxy(t, proxy, "example.test/app/game", map[string]map[string]string{
+		"v1.3.0": {
+			"go.mod":     "module example.test/app/game\n\ngo 1.25\n",
+			"legacy.foo": "// nested legacy project\n",
+		},
+	})
+	writeModuleProxy(t, proxy, "example.test/app", map[string]map[string]string{
+		"v1.0.0": {
+			"go.mod":  "module example.test/app\n\ngo 1.25\n",
+			"main.go": "package main\nfunc main() {}\n",
+		},
+		"v1.1.0": {
+			"go.mod":           "module example.test/app\n\ngo 1.25\n\nrequire example.test/framework v1.0.0 //xgo:class\n",
+			"main.go":          "package main\nfunc main() {}\n",
+			"main.foo":         "// driver-backed project\n",
+			"ordinary/main.go": "package ordinary\n",
+		},
+		"v1.2.0": {
+			"go.mod":        "module example.test/app\n\ngo 1.25\n\nrequire example.test/framework v1.0.0 //xgo:class\n",
+			"main.foo":      "// XGo-only driver-backed project\n",
+			"game/main.foo": "// XGo-only subdirectory driver-backed project\n",
+		},
+		"v1.3.0": {
+			"go.mod":        "module example.test/app\n\ngo 1.25\n\nrequire example.test/framework v1.0.0 //xgo:class\n",
+			"main.foo":      "// latest driver-backed project\n",
+			"game/main.foo": "// parent project hidden by nested module\n",
+		},
+	})
+	cache := writableModuleCache(t)
+	proxyURL := (&url.URL{Scheme: "file", Path: filepath.ToSlash(proxy)}).String()
+	t.Setenv("GOMODCACHE", cache)
+	t.Setenv("GOPROXY", proxyURL)
+	t.Setenv("GOSUMDB", "off")
+	bin := t.TempDir()
+	t.Setenv("GOBIN", bin)
+	t.Setenv("GOWORK", "off")
+
+	for _, test := range []struct {
+		name          string
+		callerVersion string
+		callerClass   bool
+		target        string
+		wantDriver    bool
+	}{
+		{name: "legacy requested version ignores driver caller graph", callerVersion: "v1.1.0", callerClass: true, target: "example.test/app@v1.0.0"},
+		{name: "driver requested version ignores legacy caller graph", callerVersion: "v1.0.0", target: "example.test/app@v1.1.0", wantDriver: true},
+		{name: "latest query uses selected version metadata", callerVersion: "v1.0.0", target: "example.test/app@latest", wantDriver: true},
+		{name: "XGo-only driver version is classified", callerVersion: "v1.0.0", target: "example.test/app@v1.2.0", wantDriver: true},
+		{name: "XGo-only subdirectory uses parent module", callerVersion: "v1.0.0", target: "example.test/app/game@v1.2.0", wantDriver: true},
+		{name: "nested module wins over parent prefix", callerVersion: "v1.0.0", target: "example.test/app/game@v1.3.0"},
+		{name: "ordinary package in driver version remains legacy", callerVersion: "v1.0.0", target: "example.test/app/ordinary@v1.1.0"},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			caller := t.TempDir()
+			marker := ""
+			if test.callerClass {
+				marker = " //xgo:class"
+			}
+			mustWriteFile(t, filepath.Join(caller, "go.mod"), fmt.Sprintf("module example.test/caller\n\ngo 1.25\n\nrequire example.test/app %s%s\n", test.callerVersion, marker))
+			resolver, err := NewResolver(context.Background(), caller, nil)
+			if err != nil {
+				t.Fatal(err)
+			}
+			_, err = resolver.Resolve(context.Background(), &xgoprojs.PkgPathProj{Path: test.target})
+			if test.wantDriver {
+				if err == nil || errors.Is(err, ErrNotHandled) || !strings.Contains(err.Error(), "@version") {
+					t.Fatalf("Resolve(%q) = %v, want explicit @version rejection", test.target, err)
+				}
+				return
+			}
+			if !errors.Is(err, ErrNotHandled) {
+				t.Fatalf("Resolve(%q) = %v, want ErrNotHandled", test.target, err)
+			}
+		})
+	}
+	entries, err := os.ReadDir(bin)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(entries) != 0 {
+		t.Fatalf("versioned package probe installed files into GOBIN: %v", entries)
+	}
+}
+
+func TestResolveVersionedPackageCanceledContext(t *testing.T) {
+	if testing.Short() {
+		t.Skip("invokes the host Go command")
+	}
+	dir := t.TempDir()
+	mustWriteFile(t, filepath.Join(dir, "go.mod"), "module example.test/caller\n\ngo 1.25\n")
+	t.Setenv("GOWORK", "off")
+	bin := t.TempDir()
+	t.Setenv("GOBIN", bin)
+	resolver, err := NewResolver(context.Background(), dir, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	_, err = resolver.Resolve(ctx, &xgoprojs.PkgPathProj{Path: "example.test/app@latest"})
+	if !errors.Is(err, context.Canceled) || errors.Is(err, ErrNotHandled) {
+		t.Fatalf("canceled versioned Resolve() = %v, want context.Canceled", err)
+	}
+	entries, readErr := os.ReadDir(bin)
+	if readErr != nil {
+		t.Fatal(readErr)
+	}
+	if len(entries) != 0 {
+		t.Fatalf("canceled versioned probe installed files into GOBIN: %v", entries)
+	}
+}
+
+func writeModuleProxy(t *testing.T, proxy, modulePath string, versions map[string]map[string]string) {
+	t.Helper()
+	escaped, err := module.EscapePath(modulePath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	moduleProxyDir := filepath.Join(proxy, filepath.FromSlash(escaped), "@v")
+	if err := os.MkdirAll(moduleProxyDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	versionNames := make([]string, 0, len(versions))
+	for version := range versions {
+		versionNames = append(versionNames, version)
+	}
+	sort.Strings(versionNames)
+	if err := os.WriteFile(filepath.Join(moduleProxyDir, "list"), []byte(strings.Join(versionNames, "\n")+"\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	for _, version := range versionNames {
+		files := versions[version]
+		source := t.TempDir()
+		for name, content := range files {
+			path := filepath.Join(source, filepath.FromSlash(name))
+			if err := os.MkdirAll(filepath.Dir(path), 0755); err != nil {
+				t.Fatal(err)
+			}
+			if err := os.WriteFile(path, []byte(content), 0644); err != nil {
+				t.Fatal(err)
+			}
+		}
+		mod := module.Version{Path: modulePath, Version: version}
+		zipPath := filepath.Join(moduleProxyDir, version+".zip")
+		zipFile, err := os.Create(zipPath)
+		if err != nil {
+			t.Fatal(err)
+		}
+		zipErr := modzip.CreateFromDir(zipFile, mod, source)
+		closeErr := zipFile.Close()
+		if zipErr != nil {
+			t.Fatal(zipErr)
+		}
+		if closeErr != nil {
+			t.Fatal(closeErr)
+		}
+		info := fmt.Sprintf("{\"Version\":%q,\"Time\":\"2026-01-01T00:00:00Z\"}\n", version)
+		if err := os.WriteFile(filepath.Join(moduleProxyDir, version+".info"), []byte(info), 0644); err != nil {
+			t.Fatal(err)
+		}
+		goMod, ok := files["go.mod"]
+		if !ok {
+			t.Fatalf("module %s@%s has no go.mod", modulePath, version)
+		}
+		if err := os.WriteFile(filepath.Join(moduleProxyDir, version+".mod"), []byte(goMod), 0644); err != nil {
+			t.Fatal(err)
+		}
+	}
+}

--- a/cmd/internal/projectdriver/signal_boundary_other.go
+++ b/cmd/internal/projectdriver/signal_boundary_other.go
@@ -1,0 +1,73 @@
+//go:build !darwin && !linux
+
+/*
+ * Copyright (c) 2026 The XGo Authors (xgo.dev). All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package projectdriver
+
+import (
+	"context"
+	"os"
+	"os/exec"
+	"os/signal"
+)
+
+type driverSignalBoundary struct {
+	ctx       context.Context
+	cancel    context.CancelFunc
+	signals   chan os.Signal
+	done      chan struct{}
+	watchDone chan struct{}
+	interrupt bool
+}
+
+func beginDriverSignalBoundary(parent context.Context) *driverSignalBoundary {
+	if parent == nil {
+		parent = context.Background()
+	}
+	ctx, cancel := context.WithCancel(parent)
+	b := &driverSignalBoundary{
+		ctx: ctx, cancel: cancel, signals: make(chan os.Signal, 1), done: make(chan struct{}), watchDone: make(chan struct{}),
+	}
+	signal.Notify(b.signals, os.Interrupt)
+	go func() {
+		defer close(b.watchDone)
+		select {
+		case <-b.signals:
+			b.interrupt = true
+			b.cancel()
+		case <-b.done:
+		}
+	}()
+	return b
+}
+
+func (b *driverSignalBoundary) Context() context.Context { return b.ctx }
+
+func (b *driverSignalBoundary) Finish(status ProcessStatus, err error) (ProcessStatus, error) {
+	signal.Stop(b.signals)
+	close(b.done)
+	<-b.watchDone
+	b.cancel()
+	if b.interrupt {
+		return ProcessStatus{Code: 130}, nil
+	}
+	return status, err
+}
+
+func exitWithSignal(os.Signal) { os.Exit(1) }
+
+func exitSignal(*exec.ExitError) (os.Signal, bool) { return nil, false }

--- a/cmd/internal/projectdriver/signal_boundary_unix.go
+++ b/cmd/internal/projectdriver/signal_boundary_unix.go
@@ -1,0 +1,100 @@
+//go:build darwin || linux
+
+/*
+ * Copyright (c) 2026 The XGo Authors (xgo.dev). All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package projectdriver
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"os/signal"
+	"syscall"
+)
+
+type driverSignalCause struct {
+	signal syscall.Signal
+}
+
+func (c driverSignalCause) Error() string {
+	return fmt.Sprintf("driver interrupted by %s", c.signal)
+}
+
+type driverSignalBoundary struct {
+	ctx       context.Context
+	cancel    context.CancelCauseFunc
+	signals   chan os.Signal
+	done      chan struct{}
+	watchDone chan struct{}
+	signal    syscall.Signal
+}
+
+func beginDriverSignalBoundary(parent context.Context) *driverSignalBoundary {
+	if parent == nil {
+		parent = context.Background()
+	}
+	ctx, cancel := context.WithCancelCause(parent)
+	b := &driverSignalBoundary{
+		ctx: ctx, cancel: cancel, signals: make(chan os.Signal, 8), done: make(chan struct{}), watchDone: make(chan struct{}),
+	}
+	signal.Notify(b.signals, syscall.SIGINT, syscall.SIGTERM, syscall.SIGHUP, syscall.SIGQUIT)
+	go func() {
+		defer close(b.watchDone)
+		for {
+			select {
+			case received := <-b.signals:
+				unixSignal, ok := received.(syscall.Signal)
+				if !ok {
+					continue
+				}
+				if b.signal == 0 {
+					b.signal = unixSignal
+					b.cancel(driverSignalCause{signal: unixSignal})
+				}
+			case <-b.done:
+				return
+			}
+		}
+	}()
+	return b
+}
+
+func (b *driverSignalBoundary) Context() context.Context { return b.ctx }
+
+func (b *driverSignalBoundary) Finish(status ProcessStatus, err error) (ProcessStatus, error) {
+	signal.Stop(b.signals)
+	close(b.done)
+	<-b.watchDone
+	b.cancel(nil)
+	received := b.signal
+	if received != 0 {
+		return ProcessStatus{Signal: received, Signaled: true}, nil
+	}
+	return status, err
+}
+
+func exitWithSignal(sig os.Signal) {
+	unixSignal, ok := sig.(syscall.Signal)
+	if !ok {
+		os.Exit(1)
+	}
+	signal.Reset(unixSignal)
+	if err := syscall.Kill(os.Getpid(), unixSignal); err != nil {
+		os.Exit(128 + int(unixSignal))
+	}
+	os.Exit(128 + int(unixSignal))
+}

--- a/cmd/internal/projectdriver/status.go
+++ b/cmd/internal/projectdriver/status.go
@@ -1,0 +1,65 @@
+/*
+ * Copyright (c) 2026 The XGo Authors (xgo.dev). All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package projectdriver
+
+import (
+	"context"
+	"errors"
+	"os"
+	"os/exec"
+)
+
+// Exit terminates a command handler with the exact driver status. Callers
+// must invoke it only after all driver/output cleanup has completed.
+func Exit(status ProcessStatus) {
+	if status.Signaled {
+		exitWithSignal(status.Signal)
+	}
+	os.Exit(status.Code)
+}
+
+func processStatus(err error) (ProcessStatus, error) {
+	if err == nil {
+		return successStatus(), nil
+	}
+	var exitErr *exec.ExitError
+	if !errors.As(err, &exitErr) {
+		return ProcessStatus{}, err
+	}
+	status := ProcessStatus{Code: exitErr.ExitCode()}
+	if signal, ok := exitSignal(exitErr); ok {
+		status.Signal, status.Signaled = signal, true
+	}
+	return status, nil
+}
+
+func statusUnlessCanceled(ctx context.Context, status ProcessStatus) (ProcessStatus, error) {
+	if status.Success() {
+		if cause := context.Cause(ctx); cause != nil {
+			return ProcessStatus{}, cause
+		}
+	}
+	return status, nil
+}
+
+func driverExitStatus(ctx context.Context, waitErr error) (ProcessStatus, error) {
+	status, err := processStatus(waitErr)
+	if err != nil {
+		return ProcessStatus{}, err
+	}
+	return statusUnlessCanceled(ctx, status)
+}

--- a/cmd/internal/projectdriver/types.go
+++ b/cmd/internal/projectdriver/types.go
@@ -1,0 +1,118 @@
+/*
+ * Copyright (c) 2026 The XGo Authors (xgo.dev). All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// Package projectdriver implements XGo's private project-driver dispatcher.
+package projectdriver
+
+import (
+	"errors"
+	"io"
+	"os"
+
+	"github.com/goplus/mod/driverprotocol"
+	"github.com/goplus/mod/xgomod"
+)
+
+const protocolV1 = driverprotocol.Version1
+
+var (
+	// ErrNotHandled means that the target is not backed by a driver.
+	// It is the only result for which callers may use the legacy GenGo path.
+	ErrNotHandled = errors.New("driver not configured")
+
+	ErrDriverVendorUnsupported = errors.New("drivers do not support vendor mode")
+	ErrDriverDisabled          = errors.New("driver execution is disabled by XGO_DRIVER=off")
+	ErrDriverRecursive         = errors.New("recursive driver invocation")
+	ErrDriverArgvTooLarge      = errors.New("driver argv and environment are too large")
+)
+
+type action = driverprotocol.Action
+
+const (
+	actionRun   = driverprotocol.ActionRun
+	actionBuild = driverprotocol.ActionBuild
+)
+
+// ModuleRef and ResolvedModule share xgomod's canonical resolved identity.
+type ModuleRef = xgomod.ModuleRef
+type ResolvedModule = xgomod.ResolvedModule
+
+type modMode string
+
+const (
+	modModeMod      modMode = "mod"
+	modModeReadonly modMode = "readonly"
+	modModeVendor   modMode = "vendor"
+)
+
+// GraphPolicy is the exact module/workspace policy shared by discovery,
+// validation, and driver construction.
+type GraphPolicy struct {
+	GoCommand string
+	GoWork    string
+	ModMode   modMode
+	ModFile   string
+	Overlay   string
+	// WorkDir anchors all Go graph operations on both sides of the wire;
+	// driver execution itself still runs in ProjectDir.
+	WorkDir string
+}
+
+// BuildPolicy is the driver-safe subset of XGo/Go build flags.
+type BuildPolicy struct {
+	Verbose         bool
+	Trace           bool
+	KeepWork        bool
+	TrimPath        bool
+	DisableBuildVCS bool
+}
+
+// Driver is the immutable discovery result passed to execution.
+type Driver struct {
+	DefaultExecName string
+	ProjectDir      string
+	ProjectFile     string
+	ModuleRoot      string
+	DriverPackage   string
+	Origin          ResolvedModule
+	ProjectExt      string
+	ProjectFullExt  string
+	PackDir         string
+	PackIndex       string
+	Declaration     xgomod.FileIdentity
+	TargetModFile   xgomod.FileIdentity
+	Graph           GraphPolicy
+	buildPolicy     BuildPolicy
+}
+
+// Streams are inherited by the driver; protocol data stays in argv.
+type Streams struct {
+	Stdin  io.Reader
+	Stdout io.Writer
+	Stderr io.Writer
+}
+
+// ProcessStatus preserves a normal exit code or an operating-system signal.
+type ProcessStatus struct {
+	Code     int
+	Signal   os.Signal
+	Signaled bool
+}
+
+// Success reports whether the driver exited normally with status zero.
+func (s ProcessStatus) Success() bool { return !s.Signaled && s.Code == 0 }
+
+func successStatus() ProcessStatus { return ProcessStatus{Code: 0} }

--- a/cmd/internal/projectdriver/version.go
+++ b/cmd/internal/projectdriver/version.go
@@ -1,0 +1,112 @@
+/*
+ * Copyright (c) 2026 The XGo Authors (xgo.dev). All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package projectdriver
+
+import (
+	"fmt"
+	"regexp"
+	"strings"
+
+	"golang.org/x/mod/module"
+	"golang.org/x/mod/semver"
+)
+
+var baseVersionRE = regexp.MustCompile(`(?:^|[^0-9])v?([0-9]+\.[0-9]+(?:\.[0-9]+)?(?:-[0-9A-Za-z.-]+)?)`)
+
+const driverV1Minimum = "1.8.0"
+
+// Development builds claim driver v1's baseline capability.
+const developmentDriverCapability = driverV1Minimum
+
+func checkDriverXGoVersion(declared, current string) error {
+	minimum, _ := normalizeXGoVersion(driverV1Minimum)
+	required := driverV1Minimum
+	if declared != "" {
+		normalized, ok := normalizeXGoVersion(declared)
+		if !ok {
+			return checkRequiredXGo(declared, current)
+		}
+		if semver.Compare(normalized, minimum) >= 0 {
+			required = declared
+		}
+	}
+	err := checkRequiredXGo(required, current)
+	if err != nil && required == driverV1Minimum {
+		return fmt.Errorf("driver v1 requires XGo %s, but xgo build is %s", driverV1Minimum, describeDriverVersion(current))
+	}
+	return err
+}
+
+func checkRequiredXGo(required, current string) error {
+	if required == "" {
+		return nil
+	}
+	requiredSemver, ok := normalizeXGoVersion(required)
+	if !ok {
+		return fmt.Errorf("invalid required XGo version %q (xgo build %s)", required, describeDriverVersion(current))
+	}
+	currentSemver, ok := comparableDriverVersion(current)
+	if !ok || semver.Compare(currentSemver, requiredSemver) < 0 {
+		return fmt.Errorf("declaring module requires XGo %s, but xgo build is %s", required, describeDriverVersion(current))
+	}
+	return nil
+}
+
+func comparableDriverVersion(version string) (string, bool) {
+	if isDevelopmentVersion(version) {
+		return normalizeXGoVersion(developmentDriverCapability)
+	}
+	return comparableCurrentVersion(version)
+}
+
+func describeDriverVersion(version string) string {
+	if isDevelopmentVersion(version) {
+		return fmt.Sprintf("%s (driver capability %s)", version, developmentDriverCapability)
+	}
+	return version
+}
+
+func isDevelopmentVersion(version string) bool {
+	version = strings.TrimSpace(version)
+	return version == "(devel)" || strings.HasSuffix(version, " devel") || module.IsPseudoVersion(version)
+}
+
+func normalizeXGoVersion(version string) (string, bool) {
+	version = strings.TrimSpace(strings.TrimPrefix(version, "v"))
+	if strings.Count(strings.SplitN(version, "-", 2)[0], ".") == 1 {
+		parts := strings.SplitN(version, "-", 2)
+		version = parts[0] + ".0"
+		if len(parts) == 2 {
+			version += "-" + parts[1]
+		}
+	}
+	version = "v" + version
+	return version, semver.IsValid(version)
+}
+
+func comparableCurrentVersion(version string) (string, bool) {
+	if normalized, ok := normalizeXGoVersion(version); ok {
+		return normalized, true
+	}
+	// Display-form versions may include a comparable semantic base. Unversioned
+	// development builds are handled by comparableDriverVersion.
+	match := baseVersionRE.FindStringSubmatch(version)
+	if len(match) != 2 {
+		return "", false
+	}
+	return normalizeXGoVersion(match[1])
+}

--- a/cmd/internal/run/run.go
+++ b/cmd/internal/run/run.go
@@ -18,6 +18,7 @@
 package run
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"reflect"
@@ -25,6 +26,7 @@ import (
 	"github.com/goplus/gogen"
 	"github.com/goplus/xgo/cl"
 	"github.com/goplus/xgo/cmd/internal/base"
+	"github.com/goplus/xgo/cmd/internal/projectdriver"
 	"github.com/goplus/xgo/tool"
 	"github.com/goplus/xgo/x/gocmd"
 	"github.com/goplus/xgo/x/xgoprojs"
@@ -75,11 +77,38 @@ func runCmd(cmd *base.Command, args []string) {
 		gogen.SetDebug(gogen.DbgFlagInstruction)
 	}
 
+	noChdir := *flagNoChdir
+	driverFlags := append([]string(nil), pass.Args...)
+	if *flagDebug {
+		driverFlags = append(driverFlags, "-debug=true")
+	}
+	if *flagQuiet {
+		driverFlags = append(driverFlags, "-quiet=true")
+	}
+	if *flagAsm {
+		driverFlags = append(driverFlags, "-asm=true")
+	}
+	if *flagNoChdir {
+		driverFlags = append(driverFlags, "-nc=true")
+	}
+	if *flagProf {
+		driverFlags = append(driverFlags, "-prof=true")
+	}
+	driverResult, driverErr := projectdriver.TryRun(context.Background(), "", proj, driverFlags, args, projectdriver.Streams{})
+	if driverErr != nil {
+		fmt.Fprintln(os.Stderr, driverErr)
+		os.Exit(1)
+	}
+	if driverResult.Handled {
+		if !driverResult.Status.Success() {
+			projectdriver.Exit(driverResult.Status)
+		}
+		return
+	}
 	if *flagProf {
 		panic("TODO: profile not impl")
 	}
 
-	noChdir := *flagNoChdir
 	conf, err := tool.NewDefaultConf(".", tool.ConfFlagNoTestFiles, pass.Tags())
 	if err != nil {
 		log.Panicln("tool.NewDefaultConf:", err)

--- a/doc/gox.mod.md
+++ b/doc/gox.mod.md
@@ -221,7 +221,31 @@ mygame/
 ```
  
 ---
- 
+
+## Project drivers
+
+A framework may delegate project execution to a verified driver executable:
+
+```text
+driver v1 example.com/framework/cmd/driver
+```
+
+The driver must be a `main` package inside the declaring module. XGo resolves
+it from the effective `go.mod`/`go.work` graph, checks the class metadata
+snapshot, then builds and runs it on the host platform. `xgo run`, `xgo build`,
+and `xgo install` use the same driver protocol.
+
+The protocol version and the declaring module's `xgo` requirement are independent.
+`driver v1` identifies the driver contract, first supported by XGo 1.8.0;
+`xgo 1.9.0` would mean only that the declaring module needs XGo 1.9.0 or
+later. The effective minimum is the higher of those two requirements.
+
+Project drivers are intentionally fail-closed: vendor and overlay-backed
+driver-backed projects are rejected, and `XGO_DRIVER=off` disables dispatch. Keep
+the driver package and its `gox.mod`/`gop.mod` in the framework module.
+
+---
+
 ## Summary
  
 `gox.mod` is the heart of XGo's classfile system, but it lives in **framework packages**, not in user projects. Ordinary XGo projects use a plain `go.mod` with `//xgo:class` annotations on their framework dependencies — that's the signal `xgo run` and other toolchain commands use to discover the relevant `gox.mod` files and learn the class structure (file patterns, class types, auto-imports) before parsing and compiling the project's source files.

--- a/go.mod
+++ b/go.mod
@@ -10,12 +10,9 @@ require (
 	github.com/goplus/lib v0.3.1
 	github.com/goplus/mod v0.22.0
 	github.com/qiniu/x v1.18.3
+	golang.org/x/mod v0.40.0
 	golang.org/x/net v0.57.0
-)
-
-require (
-	golang.org/x/mod v0.40.0 // indirect
-	golang.org/x/sys v0.47.0 // indirect
+	golang.org/x/sys v0.47.0
 )
 
 retract v1.1.12


### PR DESCRIPTION
## Summary

Supersedes [goplus/xgo#2847](https://github.com/goplus/xgo/pull/2847), which GitHub closed when its fork head branch was renamed.

This PR implements generic XGo Project Driver v1 dispatch for `xgo run`, `xgo build`, and `xgo install`. XGo discovers a framework-declared driver from the application's effective Go graph and delegates through the driver-neutral contract in [goplus/mod#165](https://github.com/goplus/mod/pull/165).

XGo owns discovery, identity validation, process supervision, and output publication. It contains no SPX, Godot, Engine, PCK, or resource-format special cases.

## Dispatch and protocol

- Dispatch driver-backed class projects before GenGo for directory, single-file, and package targets.
- Resolve class metadata and driver source from one effective module/workspace graph while honoring `GOWORK`, `-mod`, `-modfile`, and supported graph flags.
- Use `Project.Driver`, `driverprotocol`, the `xgo-driver-v1` preamble, `DriverPackage`, and `DriverOrigin` throughout `cmd/internal/projectdriver`.
- Preserve application argv boundaries, standard streams, exit status, cancellation, and platform signal semantics.
- Use `ErrNotHandled` as the only result that permits ordinary-project fallback; every error after a driver match is terminal.
- Keep the driver protocol floor independent from the declaring module's general `xgo` requirement and enforce the higher effective minimum.

## Trust and execution boundaries

- Preserve selected-module provenance separately from replacement source identity and revalidate declaration and driver origins.
- Validate driver package shape and containment, protocol version, recursion, host-only `GOOS`/`GOARCH`, pack metadata, and argv/environment budgets.
- Reject unsupported target forms, vendor-backed driver provenance, unsafe overlays, and unsupported build flags explicitly after a driver match.
- Supervise driver process trees on Unix and Windows.
- Publish build/install executables transactionally through private staging, executable validation, and atomic replacement while preserving an existing target on failure.
- Resolve install output from effective `GOBIN`, falling back to `bin` under the first `GOPATH` entry.
- Allow `XGO_DRIVER=off` to disable project-driver dispatch.

## Compatibility

Ordinary projects continue through the existing GenGo implementation. Existing public `tool.RunDir`, `tool.BuildDir`, and `tool.InstallDir` behavior is unchanged; Project Driver dispatch is currently a CLI capability.

Driver v1 is host-only. Multi-file targets, recursive patterns, `pkg@version`, cross-compilation, and unsupported graph/build modes fail explicitly once a driver-backed target is identified.

## Verification

A local `go.work` containing the Mod, XGo, and SPX checkouts was used until the companion Mod APIs are released.

```sh
go test -race ./cmd/internal/projectdriver
go test ./cmd/internal/run ./cmd/internal/build ./cmd/internal/install
go vet ./cmd/internal/projectdriver ./cmd/internal/run ./cmd/internal/build ./cmd/internal/install

# Full suite: test cl outside the coordinated workspace.
go list ./... | rg -v '^github.com/goplus/xgo/cl$' | xargs go test
GOWORK=off go test ./cl
go vet ./...
```

Host XGo and `CGO_ENABLED=0` Linux/Windows amd64 builds also pass.

## Dependency and release order

This PR depends on [goplus/mod#165](https://github.com/goplus/mod/pull/165). Mod must merge and release first, then this branch must update its `github.com/goplus/mod` requirement before XGo is released; the current `v0.21.2` requirement does not contain `driverprotocol`.

Part of [goplus/spx#1741](https://github.com/goplus/spx/issues/1741).
